### PR TITLE
chore: 新增 Cloud Agent 开发环境配置（install/start/terminals）

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -7,7 +7,7 @@
     {
       "name": "control-api",
       "description": "Control Plane API (FastAPI) @ 127.0.0.1:8600，dev 模式接本地 PostgreSQL，启动时种子 dev-tenant。",
-      "command": "export PATH=\"$HOME/.local/bin:$PATH\"; cd apps/control-api && SIQ_AS_DEV=1 SIQ_AS_DATABASE_URL=\"postgresql+psycopg://siq_as:siq_as_dev@127.0.0.1:5432/siq_as\" uv run uvicorn app.main:app --host 127.0.0.1 --port 8600"
+      "command": "export PATH=\"$HOME/.local/bin:$PATH\"; cd apps/control-api && SIQ_AS_DEV=1 SIQ_AS_DATABASE_URL=\"postgresql+psycopg://siq_as:siq_as_dev@127.0.0.1:5432/siq_as\" uv run --frozen uvicorn app.main:app --host 127.0.0.1 --port 8600"
     },
     {
       "name": "web",

--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,22 @@
+{
+  "name": "siq-agent-security",
+  "user": "ubuntu",
+  "install": "bash .cursor/install.sh",
+  "start": "bash .cursor/start.sh",
+  "terminals": [
+    {
+      "name": "control-api",
+      "description": "Control Plane API (FastAPI) @ 127.0.0.1:8600，dev 模式接本地 PostgreSQL，启动时种子 dev-tenant。",
+      "command": "export PATH=\"$HOME/.local/bin:$PATH\"; cd apps/control-api && SIQ_AS_DEV=1 SIQ_AS_DATABASE_URL=\"postgresql+psycopg://siq_as:siq_as_dev@127.0.0.1:5432/siq_as\" uv run uvicorn app.main:app --host 127.0.0.1 --port 8600"
+    },
+    {
+      "name": "web",
+      "description": "Web 控制台 (Vite) @ 127.0.0.1:5173，/api 与 /health 代理到 Control API。",
+      "command": "cd apps/web && npm run dev -- --host 127.0.0.1 --port 5173"
+    }
+  ],
+  "ports": [
+    { "name": "control-api", "port": 8600 },
+    { "name": "web", "port": 5173 }
+  ]
+}

--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -7,7 +7,7 @@
     {
       "name": "control-api",
       "description": "Control Plane API (FastAPI) @ 127.0.0.1:8600，dev 模式接本地 PostgreSQL，启动时种子 dev-tenant。",
-      "command": "export PATH=\"$HOME/.local/bin:$PATH\"; cd apps/control-api && SIQ_AS_DEV=1 SIQ_AS_DATABASE_URL=\"postgresql+psycopg://siq_as:siq_as_dev@127.0.0.1:5432/siq_as\" uv run --frozen uvicorn app.main:app --host 127.0.0.1 --port 8600"
+      "command": "export PATH=\"$HOME/.local/bin:$PATH\"; bash .cursor/start.sh; cd apps/control-api && SIQ_AS_DEV=1 SIQ_AS_DATABASE_URL=\"postgresql+psycopg://siq_as:siq_as_dev@127.0.0.1:5432/siq_as\" uv run --frozen uvicorn app.main:app --host 127.0.0.1 --port 8600"
     },
     {
       "name": "web",

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -28,8 +28,7 @@ cd "$REPO_ROOT/apps/web"
 npm ci
 [ -f .env.local ] || cp .env.example .env.local
 
-# 5) 预热 Edge Agent 与首个 Connector 的 Go 构建缓存（加速首次扫描演示）
+# 5) 预热 Edge Agent 的 Go 构建缓存（Connector 各为独立模块，按需 go build 即可）
 cd "$REPO_ROOT/edge/agent" && go build ./...
-cd "$REPO_ROOT/connectors/hermes" && go build -o hermes-connector .
 
 echo "install.sh: done"

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Cloud Agent install：幂等刷新本仓库开发依赖。
+# 语言工具链（Python 3.12 / Node 22 / Go 1.22）由默认基础镜像提供；
+# 这里补齐 uv 与 PostgreSQL 两个缺失的系统依赖，并安装各子项目依赖。
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# 1) uv（Python 包管理器）——缺失才安装
+if ! command -v uv >/dev/null 2>&1 && [ ! -x "$HOME/.local/bin/uv" ]; then
+  curl -LsSf https://astral.sh/uv/install.sh | sh
+fi
+export PATH="$HOME/.local/bin:$PATH"
+
+# 2) PostgreSQL（本地开发数据库，稳定系统依赖）——缺失才安装
+if ! command -v pg_ctlcluster >/dev/null 2>&1; then
+  sudo apt-get update -qq
+  sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq postgresql postgresql-contrib
+fi
+
+# 3) Control API Python 依赖：从提交的 uv.lock 安装。
+#    --frozen 直接按锁文件安装、不改写锁文件，可容忍与新版 uv/PyPI 索引的次要漂移。
+cd "$REPO_ROOT/apps/control-api"
+uv sync --dev --frozen
+
+# 4) Web 依赖 + 本地开发环境变量（dev 身份注入）
+cd "$REPO_ROOT/apps/web"
+npm ci
+[ -f .env.local ] || cp .env.example .env.local
+
+# 5) 预热 Edge Agent 与首个 Connector 的 Go 构建缓存（加速首次扫描演示）
+cd "$REPO_ROOT/edge/agent" && go build ./...
+cd "$REPO_ROOT/connectors/hermes" && go build -o hermes-connector .
+
+echo "install.sh: done"

--- a/.cursor/start.sh
+++ b/.cursor/start.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Cloud Agent start：每次开机把本地 PostgreSQL 拉起并把控制面数据库迁到最新。
+# 必须可重复执行（容忍已启动）、就绪后返回，不常驻前台。
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+export PATH="$HOME/.local/bin:$PATH"
+
+# 1) 启动 PostgreSQL 集群（容忍已运行）
+sudo pg_ctlcluster 16 main start 2>/dev/null || true
+
+# 2) 等待就绪
+for _ in $(seq 1 30); do
+  if sudo -u postgres pg_isready -q; then break; fi
+  sleep 1
+done
+
+# 3) 幂等确保开发角色与数据库存在（口令仅本地开发用，与 deploy/compose 一致）
+sudo -u postgres psql -tAc "SELECT 1 FROM pg_roles WHERE rolname='siq_as'" | grep -q 1 \
+  || sudo -u postgres psql -c "CREATE ROLE siq_as LOGIN PASSWORD 'siq_as_dev';"
+sudo -u postgres psql -tAc "SELECT 1 FROM pg_database WHERE datname='siq_as'" | grep -q 1 \
+  || sudo -u postgres psql -c "CREATE DATABASE siq_as OWNER siq_as;"
+
+# 4) 迁移到最新（干净库可全量回放；已在最新则为空操作）
+cd "$REPO_ROOT/apps/control-api"
+export SIQ_AS_DEV=1
+export SIQ_AS_DATABASE_URL="postgresql+psycopg://siq_as:siq_as_dev@127.0.0.1:5432/siq_as"
+uv run alembic upgrade head
+
+echo "start.sh: PostgreSQL ready and migrations applied"

--- a/.cursor/start.sh
+++ b/.cursor/start.sh
@@ -25,6 +25,6 @@ sudo -u postgres psql -tAc "SELECT 1 FROM pg_database WHERE datname='siq_as'" | 
 cd "$REPO_ROOT/apps/control-api"
 export SIQ_AS_DEV=1
 export SIQ_AS_DATABASE_URL="postgresql+psycopg://siq_as:siq_as_dev@127.0.0.1:5432/siq_as"
-uv run alembic upgrade head
+uv run --frozen alembic upgrade head
 
 echo "start.sh: PostgreSQL ready and migrations applied"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 目的

为本仓库新增一套版本化的 Cloud Agent 开发环境（`.cursor/environment.json` + 安装/启动脚本），让新 Agent 开箱即可运行 Control API、Web 控制台，并跑通 Edge/Connector 扫描流水线与全套校验。

## 变更内容

- `.cursor/environment.json`：repo-file 管理的环境定义（默认基础镜像 + `install`/`start`/`terminals`/`ports`）。
- `.cursor/install.sh`：幂等安装。默认镜像已含 Python 3.12 / Node 22 / Go 1.22，脚本补齐两个缺失的系统依赖 **uv** 与 **PostgreSQL 16**，并 `uv sync --dev --frozen`（Control API）、`npm ci`（Web）、预热 Edge Go 构建缓存。
- `.cursor/start.sh`：每次开机幂等拉起本地 PostgreSQL、确保开发角色/库存在、`alembic upgrade head`。
- `terminals`：`control-api`（FastAPI @ 127.0.0.1:8600，dev 模式接本地 PostgreSQL）、`web`（Vite @ 127.0.0.1:5173，`/api` 与 `/health` 代理到 Control API）。`control-api` 终端会先幂等执行 `start.sh`，即使 `start` 钩子未触发也能自愈拉起数据库。

## 设计要点

- **不改动任何产品代码**，仅新增环境配置与脚本；工作树保持干净（`install.sh` 不产生未跟踪产物）。
- **锁文件不改写**：仓库 `uv.lock` 与当前新版 uv/PyPI 索引存在既有次要漂移（`virtual`→`editable` + 新增 greenlet 平台 wheel），故运行期统一用 `uv sync --dev --frozen` / `uv run --frozen` 按锁文件安装、不触碰 `uv.lock`，与仓库既有状态一致（此漂移为既有情况，非本 PR 引入）。
- **安全不变量不受影响**：dev 模式身份头仅本地生效；PostgreSQL 口令与 `deploy/compose/compose.yaml` 一致，仅本地开发用，非生产密钥。

## 验证（本 VM）

| 检查 | 结果 |
| --- | --- |
| `ruff check app` | 通过 |
| `pytest`（Control API） | 323 passed |
| `alembic upgrade head`（干净 PostgreSQL 全量回放 0001→0013） | 通过 |
| Web `npm ci && npm run build` | 通过（0 vulnerabilities） |
| Edge + 11 Connector `gofmt`/`build`/`vet`/`test -race` | 全部通过 |
| Edge `run-once` Hermes 本地扫描（NDJSON 子进程协议） | 产出 candidate + 双 evidence 回链 |
| Web → Vite 代理 → Control API → PostgreSQL 端到端 | 通过（控制台显示实时数据） |
| `install.sh` 幂等（连跑两次） | 通过 |

## 验证（从构建产物启动的全新 Cloud Agent）

以 `install.sh`/`start.sh` 从全新 checkout 触发 draft build 成功；全新 Agent 复核：工具链版本、依赖安装、PostgreSQL + 迁移（0013 head）、323 项测试、`/health` 与环境 CRUD（HTTP 201）、Edge Go 构建——全部 PASS。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-745dfcf8-e626-4d35-a9c3-fce23db4438b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-745dfcf8-e626-4d35-a9c3-fce23db4438b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

