### PR TITLE
research: record published source release and verified evidence

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -15,3 +15,5 @@ keywords:
   - reproducibility
   - effect evidence
 license: Apache-2.0
+version: "research-v0.1.0-rc.1"
+date-released: "2026-09-08"

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 研究入口：[研究指南](docs/research/README.md) · [无模型密钥复现](REPRODUCIBILITY.md) · [引用](CITATION.cff) · [贡献](CONTRIBUTING.md) · [安全报告](SECURITY.md)。自有代码采用 [Apache-2.0](LICENSE)，明确列出的原创研究文档采用 [CC BY 4.0](LICENSES/README.md)，第三方许可保留。
 
+首个[研究源码预发布 research-v0.1.0-rc.1](https://github.com/maoyadongsh/siq-agent-security/releases/tag/research-v0.1.0-rc.1)已上线（未签名，附来源清单与校验和）。
+
 本轮研究开源操作与验证见[实施记录](docs/research/operations-20260908.md)。比赛 V5 材料保留为原始冻结快照；新实验使用独立身份。当前没有论文、DOI 或独立复现认证。
 
 ## Secure Runtime for Agent Skills

--- a/docs/open-source-research-tasks-20260908.json
+++ b/docs/open-source-research-tasks-20260908.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "siq-research-open-source-tasks/v1",
-  "updated_at": "2026-09-08T15:06:01.179243+00:00",
+  "updated_at": "2026-09-08T15:14:39.685239+00:00",
   "source_document": "docs/open-source-research-plan-20260908.md",
   "source_document_sha256": "b2e9a1e927c8e90e2994bcfe4beb4d0358e33d638486908ccbfacc5f9a601ab2",
   "repository": "maoyadongsh/siq-agent-security",
@@ -8,7 +8,7 @@
   "recording_head_sha": "e72e8b36a71ae7f7f1fecd587bbe6eb2353f24d2",
   "frozen_v5_runtime_sha": "d1277116e8291e72b09b0462a19d0268b68bf46c",
   "frozen_v5_documentation_sha": "e72e8b36a71ae7f7f1fecd587bbe6eb2353f24d2",
-  "research_submission_sha": null,
+  "research_submission_sha": "aefab111c7fcad9075c8f429f97c9eab519dcd22",
   "scope": "研究开源实施：实际证据更新状态；冻结比赛制品不变，长期外部研究里程碑不因仓库设置完成而自动完成。",
   "status_definitions": {
     "todo": "尚未开始；已有历史能力不能替代本周期验收",
@@ -324,7 +324,7 @@
       "phase": "第 2 周",
       "owner_role_from_plan": "发布维护者",
       "source_acceptance": "依赖 O-03/04/07/08；精确 SHA 的 CI 与完整制品核验通过",
-      "status": "in_progress",
+      "status": "done",
       "task_ids": [
         "O-10.01",
         "O-10.02",
@@ -739,7 +739,7 @@
         "O-04.04",
         "O-05.02"
       ],
-      "state": "not_met"
+      "state": "met"
     },
     {
       "id": "G-02",
@@ -753,7 +753,7 @@
         "O-09.02",
         "O-10.05"
       ],
-      "state": "not_met"
+      "state": "met"
     },
     {
       "id": "G-03",
@@ -3247,7 +3247,7 @@
       ],
       "priority": "P0",
       "kind": "validation",
-      "status": "in_progress",
+      "status": "done",
       "owner_role": "maintainer",
       "assignee": "maoyadongsh",
       "depends_on": [
@@ -3277,13 +3277,23 @@
         "实际执行时间、源码 SHA、输入/输出摘要、执行命令或审阅记录、结果与限制；仅记录已发生的事实。",
         "外部操作附真实 readback/URL/receipt；材料只做白名单导出，不公开凭据、私钥或原始私密状态。"
       ],
-      "validation": [],
+      "validation": [
+        {
+          "method": "final main 31 checks; source archive member/license checks; actual GitHub release and fresh download",
+          "result": "passed_for_source_only_release",
+          "evidence": [
+            "docs/research/evidence/release-ci.json",
+            "docs/research/evidence/release-regression.json"
+          ],
+          "limitations": "没有新增二进制/模型权重分发或原生包启动认证；对应未来发行另行验证。"
+        }
+      ],
       "evidence": [
-        "docs/research/release-scope.md",
-        "docs/research/publication-plan.md"
+        "docs/research/evidence/release-ci.json",
+        "docs/research/evidence/release-regression.json"
       ],
       "blocker": null,
-      "completed_at": null,
+      "completed_at": "2026-09-08T15:14:39.685239+00:00",
       "planned_validation": [
         {
           "method": "逐项核对验收条件",
@@ -3313,7 +3323,7 @@
       ],
       "priority": "P0",
       "kind": "validation",
-      "status": "in_progress",
+      "status": "done",
       "owner_role": "maintainer",
       "assignee": "maoyadongsh",
       "depends_on": [
@@ -3338,13 +3348,21 @@
         "实际执行时间、源码 SHA、输入/输出摘要、执行命令或审阅记录、结果与限制；仅记录已发生的事实。",
         "外部操作附真实 readback/URL/receipt；材料只做白名单导出，不公开凭据、私钥或原始私密状态。"
       ],
-      "validation": [],
+      "validation": [
+        {
+          "method": "final main 31 checks; source archive member/license checks; actual GitHub release and fresh download",
+          "result": "passed_for_source_only_release",
+          "evidence": [
+            "docs/research/evidence/research-rc.json"
+          ],
+          "limitations": "没有新增二进制/模型权重分发或原生包启动认证；对应未来发行另行验证。"
+        }
+      ],
       "evidence": [
-        "docs/research/release-scope.md",
-        "docs/research/publication-plan.md"
+        "docs/research/evidence/research-rc.json"
       ],
       "blocker": null,
-      "completed_at": null,
+      "completed_at": "2026-09-08T15:14:39.685239+00:00",
       "planned_validation": [
         {
           "method": "逐项核对验收条件",
@@ -3376,7 +3394,7 @@
       ],
       "priority": "P0",
       "kind": "documentation",
-      "status": "in_progress",
+      "status": "done",
       "owner_role": "maintainer",
       "assignee": "maoyadongsh",
       "depends_on": [
@@ -3402,13 +3420,25 @@
         "实际执行时间、源码 SHA、输入/输出摘要、执行命令或审阅记录、结果与限制；仅记录已发生的事实。",
         "外部操作附真实 readback/URL/receipt；材料只做白名单导出，不公开凭据、私钥或原始私密状态。"
       ],
-      "validation": [],
+      "validation": [
+        {
+          "method": "final main 31 checks; source archive member/license checks; actual GitHub release and fresh download",
+          "result": "passed_for_source_only_release",
+          "evidence": [
+            "docs/research/release-notes.md",
+            "docs/research/publication-plan.md",
+            "docs/research/evidence/research-rc.json"
+          ],
+          "limitations": "没有新增二进制/模型权重分发或原生包启动认证；对应未来发行另行验证。"
+        }
+      ],
       "evidence": [
-        "docs/research/release-scope.md",
-        "docs/research/publication-plan.md"
+        "docs/research/release-notes.md",
+        "docs/research/publication-plan.md",
+        "docs/research/evidence/research-rc.json"
       ],
       "blocker": null,
-      "completed_at": null,
+      "completed_at": "2026-09-08T15:14:39.685239+00:00",
       "planned_validation": [
         {
           "method": "逐项核对验收条件",
@@ -3430,7 +3460,7 @@
       ],
       "priority": "P0",
       "kind": "external_manual",
-      "status": "in_progress",
+      "status": "done",
       "owner_role": "release_maintainer",
       "assignee": "maoyadongsh",
       "depends_on": [
@@ -3458,13 +3488,21 @@
         "实际执行时间、源码 SHA、输入/输出摘要、执行命令或审阅记录、结果与限制；仅记录已发生的事实。",
         "外部操作附真实 readback/URL/receipt；材料只做白名单导出，不公开凭据、私钥或原始私密状态。"
       ],
-      "validation": [],
+      "validation": [
+        {
+          "method": "final main 31 checks; source archive member/license checks; actual GitHub release and fresh download",
+          "result": "passed_for_source_only_release",
+          "evidence": [
+            "docs/research/evidence/github-research-release.json"
+          ],
+          "limitations": "没有新增二进制/模型权重分发或原生包启动认证；对应未来发行另行验证。"
+        }
+      ],
       "evidence": [
-        "docs/research/release-scope.md",
-        "docs/research/publication-plan.md"
+        "docs/research/evidence/github-research-release.json"
       ],
       "blocker": null,
-      "completed_at": null,
+      "completed_at": "2026-09-08T15:14:39.685239+00:00",
       "planned_validation": [
         {
           "method": "逐项核对验收条件",
@@ -5118,11 +5156,11 @@
     "workstreams": 18,
     "tasks": 71,
     "status_counts": {
-      "done": 43,
+      "done": 47,
       "not_applicable": 1,
       "todo": 20,
-      "in_progress": 6,
-      "blocked": 1
+      "blocked": 1,
+      "in_progress": 2
     },
     "kind_counts": {
       "engineering": 9,
@@ -5136,5 +5174,12 @@
       "recurring": 2
     }
   },
-  "execution_branch": "codex/research-open-source-r1"
+  "execution_branch": "codex/research-open-source-r1",
+  "published_research_source": {
+    "version": "research-v0.1.0-rc.1",
+    "sha": "aefab111c7fcad9075c8f429f97c9eab519dcd22",
+    "url": "https://github.com/maoyadongsh/siq-agent-security/releases/tag/research-v0.1.0-rc.1",
+    "kind": "source-only unsigned prerelease",
+    "recording_note": "publication receipts are committed after the release and do not replace its source SHA"
+  }
 }

--- a/docs/open-source-research-tasks-20260908.md
+++ b/docs/open-source-research-tasks-20260908.md
@@ -3,13 +3,13 @@
 [方案原文](open-source-research-plan-20260908.md) · [机器可读台账](open-source-research-tasks-20260908.json)
 
 原文 18 个阶段已拆分为 **71 项执行任务**，覆盖全部 12 节。
-当前状态：`done` 43 项；`not_applicable` 1 项；`todo` 20 项；`in_progress` 6 项；`blocked` 1 项。任务登记不等于工程实施或外部发布完成。
+当前状态：`done` 47 项；`not_applicable` 1 项；`todo` 20 项；`blocked` 1 项；`in_progress` 2 项。任务登记不等于工程实施或外部发布完成。
 
 ## 基线与执行规则
 
 - 登记基线：`e72e8b36a71ae7f7f1fecd587bbe6eb2353f24d2`；登记分支：`codex/hackathon-final-release-v5`。
 - V5 运行源码：`d1277116e8291e72b09b0462a19d0268b68bf46c`；原文档提交独立保留。
-- 研究 submission SHA：`尚未确定`。
+- 研究 submission SHA：`aefab111c7fcad9075c8f429f97c9eab519dcd22`。
 - 方案 SHA256：`b2e9a1e927c8e90e2994bcfe4beb4d0358e33d638486908ccbfacc5f9a601ab2`。
 
 - JSON 为执行状态事实源，Markdown 是同内容的阅读投影；修改状态时两者同步并重算汇总。
@@ -66,7 +66,7 @@ python3 scripts/check_research_task_ledger.py
 | O-07 | A/B/C 三轨复现说明 | 第 2 周 | 5 | in_progress |
 | O-08 | 研究导航、dataset card、claims-evidence 表 | 第 2 周 | 5 | done |
 | O-09 | CITATION.cff 与真实作者/版本元数据 | 第 2 周 | 3 | done |
-| O-10 | 从新 SHA 生成研究候选 | 第 2 周 | 5 | in_progress |
+| O-10 | 从新 SHA 生成研究候选 | 第 2 周 | 5 | done |
 | O-11 | 发布、归档和版本引用验证 | 第 2–4 周 | 4 | blocked |
 | O-12 | 收集两组外部复现记录 | 第 2–4 周 | 4 | in_progress |
 | O-13 | 发布研究导读与技术报告 | 第 2–4 周 | 4 | in_progress |
@@ -82,8 +82,8 @@ python3 scripts/check_research_task_ledger.py
 
 | 门禁 | 达成条件 | 必需任务 | 前置门禁 | 当前 |
 | --- | --- | --- | --- | --- |
-| G-01 | 许可与历史处置具备首发条件 | O-01.03, O-02.03, O-03.04, O-04.04, O-05.02 | 无 | not_met |
-| G-02 | 无需模型的复现与可核验研究候选就绪 | O-07.02, O-07.03, O-07.05, O-08.03, O-08.05, O-09.02, O-10.05 | 无 | not_met |
+| G-01 | 许可与历史处置具备首发条件 | O-01.03, O-02.03, O-03.04, O-04.04, O-05.02 | 无 | met |
+| G-02 | 无需模型的复现与可核验研究候选就绪 | O-07.02, O-07.03, O-07.05, O-08.03, O-08.05, O-09.02, O-10.05 | 无 | met |
 | G-03 | 首轮研究版公开发布与长期引用闭环 | O-06.02, O-06.03, O-11.04 | G-01, G-02 | not_met |
 | G-04 | 外部复现目标达到 | O-12.03 | G-03 | not_met |
 | G-05 | 首发传播材料与社区入口齐备 | O-13.04, O-14.03, O-18.01 | G-03 | not_met |
@@ -1092,10 +1092,11 @@ G-01～G-03 为首轮研究发行；G-04 为外部复现；G-05 为传播/社区
 
 #### O-10.04 · 执行新研究 SHA 的 CI 与受影响回归
 
-- 状态：`in_progress`；优先级：`P0`；类型：`validation`；责任角色：`maintainer`；负责人：maoyadongsh。
+- 状态：`done`；优先级：`P0`；类型：`validation`；责任角色：`maintainer`；负责人：maoyadongsh。
 - 原文依据：§9。
 - 完成依赖：O-10.02, O-10.03, O-09.02, O-03.04, O-05.02, O-06.04；待决策依赖：无。
 - 计划产物：`docs/research/evidence/release-ci.json`；`docs/research/evidence/release-regression.json`。
+- 完成时间：2026-09-08T15:14:39.685239+00:00。
 
 实施内容：
 
@@ -1112,15 +1113,16 @@ G-01～G-03 为首轮研究发行；G-04 为外部复现；G-05 为传播/社区
 - 逐项核对验收条件：旧 d127711 CI 不冒充新研究 SHA 的结果；最终源码变动触发相应重验；仅文档变更做链接/格式检查，打包或安全变更执行相应有意义验证，不盲目重复全部检查。全部适用条件满足，并写入实际 validation/evidence；未执行不算通过。
 - 计划验证命令或方法（含占位符时不可原样执行）：go test ./... / go test -race ./... / go vet ./...（仅受影响 Go module；保留实际 cwd）；复用现有 ci/runtime-security 对最终 SHA 运行；文档仅做链接/格式校验，打包增量运行现有 package tests。。执行时填入实际路径、版本与范围，保存退出码/结果和证据。
 
-实际验证：`[]`。
-实际证据：`["docs/research/release-scope.md", "docs/research/publication-plan.md"]`。
+实际验证：`[{"method": "final main 31 checks; source archive member/license checks; actual GitHub release and fresh download", "result": "passed_for_source_only_release", "evidence": ["docs/research/evidence/release-ci.json", "docs/research/evidence/release-regression.json"], "limitations": "没有新增二进制/模型权重分发或原生包启动认证；对应未来发行另行验证。"}]`。
+实际证据：`["docs/research/evidence/release-ci.json", "docs/research/evidence/release-regression.json"]`。
 
 #### O-10.05 · 从干净源码构建并验收研究候选
 
-- 状态：`in_progress`；优先级：`P0`；类型：`validation`；责任角色：`maintainer`；负责人：maoyadongsh。
+- 状态：`done`；优先级：`P0`；类型：`validation`；责任角色：`maintainer`；负责人：maoyadongsh。
 - 原文依据：§9、§6.1。
 - 完成依赖：O-10.04；待决策依赖：无。
 - 计划产物：`docs/research/evidence/research-rc.json`；`研究候选包（Git 之外）`。
+- 完成时间：2026-09-08T15:14:39.685239+00:00。
 
 实施内容：
 
@@ -1137,8 +1139,8 @@ G-01～G-03 为首轮研究发行；G-04 为外部复现；G-05 为传播/社区
 - 逐项核对验收条件：最终 SHA 具备成功 CI；制品指向实际源码而非 dirty-source manifest；原生验收与 cross-build 区分；包内不含秘密/私密状态；启动后包未污染。全部适用条件满足，并写入实际 validation/evidence；未执行不算通过。
 - 计划验证命令或方法（含占位符时不可原样执行）：git status --porcelain（构建前后均为空）；python3 scripts/hackathon/package_rc.py --out <新候选目录> --verify-only；sha256sum -c SHA256SUMS（候选内和外层分别核查，记录 cwd）。执行时填入实际路径、版本与范围，保存退出码/结果和证据。
 
-实际验证：`[]`。
-实际证据：`["docs/research/release-scope.md", "docs/research/publication-plan.md"]`。
+实际验证：`[{"method": "final main 31 checks; source archive member/license checks; actual GitHub release and fresh download", "result": "passed_for_source_only_release", "evidence": ["docs/research/evidence/research-rc.json"], "limitations": "没有新增二进制/模型权重分发或原生包启动认证；对应未来发行另行验证。"}]`。
+实际证据：`["docs/research/evidence/research-rc.json"]`。
 
 ### O-11 · 发布、归档和版本引用验证
 
@@ -1146,10 +1148,11 @@ G-01～G-03 为首轮研究发行；G-04 为外部复现；G-05 为传播/社区
 
 #### O-11.01 · 准备可审阅的研究发布与归档材料
 
-- 状态：`in_progress`；优先级：`P0`；类型：`documentation`；责任角色：`maintainer`；负责人：maoyadongsh。
+- 状态：`done`；优先级：`P0`；类型：`documentation`；责任角色：`maintainer`；负责人：maoyadongsh。
 - 原文依据：§6.2、§9、§10.1。
 - 完成依赖：O-10.05, O-09.03；待决策依赖：无。
 - 计划产物：`docs/research/release-notes.md`；`docs/research/publication-plan.md`。
+- 完成时间：2026-09-08T15:14:39.685239+00:00。
 
 实施内容：
 
@@ -1165,15 +1168,16 @@ G-01～G-03 为首轮研究发行；G-04 为外部复现；G-05 为传播/社区
 
 - 逐项核对验收条件：材料可独立审阅，版本/哈希/许可一致；没有发布授权时仍完成准备；不生成假 Release URL 或 DOI。全部适用条件满足，并写入实际 validation/evidence；未执行不算通过。
 
-实际验证：`[]`。
-实际证据：`["docs/research/release-scope.md", "docs/research/publication-plan.md"]`。
+实际验证：`[{"method": "final main 31 checks; source archive member/license checks; actual GitHub release and fresh download", "result": "passed_for_source_only_release", "evidence": ["docs/research/release-notes.md", "docs/research/publication-plan.md", "docs/research/evidence/research-rc.json"], "limitations": "没有新增二进制/模型权重分发或原生包启动认证；对应未来发行另行验证。"}]`。
+实际证据：`["docs/research/release-notes.md", "docs/research/publication-plan.md", "docs/research/evidence/research-rc.json"]`。
 
 #### O-11.02 · 发布新研究版本至 GitHub
 
-- 状态：`in_progress`；优先级：`P0`；类型：`external_manual`；责任角色：`release_maintainer`；负责人：maoyadongsh。
+- 状态：`done`；优先级：`P0`；类型：`external_manual`；责任角色：`release_maintainer`；负责人：maoyadongsh。
 - 原文依据：§9、§6.2。
 - 完成依赖：O-11.01, O-06.02, O-06.03；待决策依赖：D-06。
 - 计划产物：`docs/research/evidence/github-research-release.json`。
+- 完成时间：2026-09-08T15:14:39.685239+00:00。
 
 实施内容：
 
@@ -1189,8 +1193,8 @@ G-01～G-03 为首轮研究发行；G-04 为外部复现；G-05 为传播/社区
 
 - 逐项核对验收条件：实际 Release URL 和资产校验通过；不覆盖既有 tag 或旧文件；若要求集成后 main 为源码，须先回 O-10.04/05 重冻重建，不直接沿用分支包。全部适用条件满足，并写入实际 validation/evidence；未执行不算通过。
 
-实际验证：`[]`。
-实际证据：`["docs/research/release-scope.md", "docs/research/publication-plan.md"]`。
+实际验证：`[{"method": "final main 31 checks; source archive member/license checks; actual GitHub release and fresh download", "result": "passed_for_source_only_release", "evidence": ["docs/research/evidence/github-research-release.json"], "limitations": "没有新增二进制/模型权重分发或原生包启动认证；对应未来发行另行验证。"}]`。
+实际证据：`["docs/research/evidence/github-research-release.json"]`。
 
 #### O-11.03 · 连接归档账号并保存实际研究制品
 

--- a/docs/research/citation-guide.md
+++ b/docs/research/citation-guide.md
@@ -5,3 +5,5 @@ Use [CITATION.cff](../../CITATION.cff) for the software title and confirmed publ
 Repository: https://github.com/maoyadongsh/siq-agent-security. There is no paper or DOI to cite yet. Use the immutable GitHub commit URL for an exact source reference. A future GitHub release, source archive, dataset or video may be archived separately; do not assume they share one DOI or that a concept DOI identifies a particular experiment.
 
 When a real archival account is connected, verify version/concept DOI distinction, file contents and destination hashes, then update the software reference for the published version. Citation is encouraged for software, without imposing an extra Apache license restriction. CC BY material attribution follows LICENSES/README.md.
+
+Published source version: [research-v0.1.0-rc.1](https://github.com/maoyadongsh/siq-agent-security/releases/tag/research-v0.1.0-rc.1), 2026-09-08, exact source `aefab111c7fcad9075c8f429f97c9eab519dcd22`. The CFF version/date update is recorded after publication; the original source archive retains its original bytes. No DOI has been assigned.

--- a/docs/research/citation-policy.md
+++ b/docs/research/citation-policy.md
@@ -1,6 +1,6 @@
 # Citation and archival policy
 
-CITATION.cff names the confirmed repository owner by the public identifier `maoyadongsh`. No surname, legal identity, employer, ORCID, paper author list or DOI was invented. The software citation has no release date/version until a corresponding version is actually published. For current use, include the exact commit and the report/corpus digests in your methods.
+CITATION.cff names the confirmed repository owner by the public identifier `maoyadongsh`. No surname, legal identity, employer, ORCID, paper author list or DOI was invented. The software citation now records the actually published source version research-v0.1.0-rc.1 and its 2026-09-08 release date. For current use, include the exact commit and the report/corpus digests in your methods.
 
 Recommend software citation without imposing an additional Apache license condition. Paper authorship is separately agreed based on scholarly contribution. Credit external reproductions only with actual consent; an AI tool is not a paper author.
 

--- a/docs/research/evidence/citation-validation.json
+++ b/docs/research/evidence/citation-validation.json
@@ -1,10 +1,12 @@
 {
-  "checked_at": "2026-09-08T14:57:14.153352+00:00",
+  "checked_at": "2026-09-08T15:14:39.746932+00:00",
   "command": "jsonschema.validate(yaml.safe_load(CITATION.cff), CFF 1.2.0 schema)",
   "schema_source": "https://raw.githubusercontent.com/citation-file-format/citation-file-format/1.2.0/schema.json",
   "schema_sha256": "0b8d22140da702d766df318dcff3a91af2f39521298dcf36d76315fd99cc169b",
-  "citation_sha256": "b2a8373075f0ea0f699ec5d3a19db67df1f545e15a58f012b859949e47500644",
+  "citation_sha256": "2b680b7a8446cd182a802063aab558f7d984633bccdbedcc50dec0f164643490",
   "result": "passed",
   "doi": null,
-  "paper": null
+  "paper": null,
+  "release_version": "research-v0.1.0-rc.1",
+  "release_url": "https://github.com/maoyadongsh/siq-agent-security/releases/tag/research-v0.1.0-rc.1"
 }

--- a/docs/research/evidence/github-research-release.json
+++ b/docs/research/evidence/github-research-release.json
@@ -1,0 +1,45 @@
+{
+  "observed_at": "2026-09-08T15:13:01.825799+00:00",
+  "url": "https://github.com/maoyadongsh/siq-agent-security/releases/tag/research-v0.1.0-rc.1",
+  "release_id": 384842287,
+  "tag": "research-v0.1.0-rc.1",
+  "tag_source_sha": "aefab111c7fcad9075c8f429f97c9eab519dcd22",
+  "published_at": "2026-09-08T15:12:02Z",
+  "prerelease": true,
+  "draft": false,
+  "artifact_kind": "source-only",
+  "official_signature": false,
+  "assets": [
+    {
+      "name": "SHA256SUMS",
+      "url": "https://github.com/maoyadongsh/siq-agent-security/releases/download/research-v0.1.0-rc.1/SHA256SUMS",
+      "size": 196
+    },
+    {
+      "name": "siq-agent-security-research-v0.1.0-rc.1.tar.gz",
+      "url": "https://github.com/maoyadongsh/siq-agent-security/releases/download/research-v0.1.0-rc.1/siq-agent-security-research-v0.1.0-rc.1.tar.gz",
+      "size": 52347840
+    },
+    {
+      "name": "SOURCE-INFO.json",
+      "url": "https://github.com/maoyadongsh/siq-agent-security/releases/download/research-v0.1.0-rc.1/SOURCE-INFO.json",
+      "size": 289045
+    }
+  ],
+  "fresh_download_verified": [
+    {
+      "name": "siq-agent-security-research-v0.1.0-rc.1.tar.gz",
+      "sha256": "4a741a767faae5875ab2ec765b1c91d7f0eca076f5de67cff97ea59d1d4b1779",
+      "bytes": 52347840
+    },
+    {
+      "name": "SOURCE-INFO.json",
+      "sha256": "262f5f25242553adb80e67de7d248a184e3ece87bb975653609791c898fbfaaf",
+      "bytes": 289045
+    }
+  ],
+  "archive_members_verified": 2058,
+  "archive_license_notice_files": 98,
+  "doi": null,
+  "independent_external_reproduction": false
+}

--- a/docs/research/evidence/release-ci.json
+++ b/docs/research/evidence/release-ci.json
@@ -1,0 +1,162 @@
+{
+  "observed_at": "2026-09-08T15:11:54.758771+00:00",
+  "source_sha": "aefab111c7fcad9075c8f429f97c9eab519dcd22",
+  "checks": [
+    {
+      "name": "web",
+      "conclusion": "success",
+      "url": "https://github.com/maoyadongsh/siq-agent-security/actions/runs/34242906726/job/102117371282"
+    },
+    {
+      "name": "agentshield",
+      "conclusion": "success",
+      "url": "https://github.com/maoyadongsh/siq-agent-security/actions/runs/34242906726/job/102117371743"
+    },
+    {
+      "name": "gitleaks",
+      "conclusion": "success",
+      "url": "https://github.com/maoyadongsh/siq-agent-security/actions/runs/34242906726/job/102117371844"
+    },
+    {
+      "name": "control-api",
+      "conclusion": "success",
+      "url": "https://github.com/maoyadongsh/siq-agent-security/actions/runs/34242906726/job/102117371779"
+    },
+    {
+      "name": "edge (1.22, connectors/directory)",
+      "conclusion": "success",
+      "url": "https://github.com/maoyadongsh/siq-agent-security/actions/runs/34242906726/job/102117372007"
+    },
+    {
+      "name": "edge (1.22, connectors/hermes)",
+      "conclusion": "success",
+      "url": "https://github.com/maoyadongsh/siq-agent-security/actions/runs/34242906726/job/102117371857"
+    },
+    {
+      "name": "edge (stable, edge/agent)",
+      "conclusion": "success",
+      "url": "https://github.com/maoyadongsh/siq-agent-security/actions/runs/34242906726/job/102117372048"
+    },
+    {
+      "name": "edge (1.22, connectors/kubernetes)",
+      "conclusion": "success",
+      "url": "https://github.com/maoyadongsh/siq-agent-security/actions/runs/34242906726/job/102117371977"
+    },
+    {
+      "name": "edge (1.22, edge/agent)",
+      "conclusion": "success",
+      "url": "https://github.com/maoyadongsh/siq-agent-security/actions/runs/34242906726/job/102117371934"
+    },
+    {
+      "name": "edge (1.22, connectors/dify)",
+      "conclusion": "success",
+      "url": "https://github.com/maoyadongsh/siq-agent-security/actions/runs/34242906726/job/102117371976"
+    },
+    {
+      "name": "edge (1.22, connectors/docker)",
+      "conclusion": "success",
+      "url": "https://github.com/maoyadongsh/siq-agent-security/actions/runs/34242906726/job/102117372073"
+    },
+    {
+      "name": "edge (stable, connectors/docker)",
+      "conclusion": "success",
+      "url": "https://github.com/maoyadongsh/siq-agent-security/actions/runs/34242906726/job/102117372145"
+    },
+    {
+      "name": "edge (1.22, connectors/openclaw)",
+      "conclusion": "success",
+      "url": "https://github.com/maoyadongsh/siq-agent-security/actions/runs/34242906726/job/102117372041"
+    },
+    {
+      "name": "edge (stable, connectors/process)",
+      "conclusion": "success",
+      "url": "https://github.com/maoyadongsh/siq-agent-security/actions/runs/34242906726/job/102117372173"
+    },
+    {
+      "name": "edge (1.22, connectors/systemd)",
+      "conclusion": "success",
+      "url": "https://github.com/maoyadongsh/siq-agent-security/actions/runs/34242906726/job/102117372250"
+    },
+    {
+      "name": "edge (1.22, connectors/process)",
+      "conclusion": "success",
+      "url": "https://github.com/maoyadongsh/siq-agent-security/actions/runs/34242906726/job/102117371908"
+    },
+    {
+      "name": "edge (stable, connectors/systemd)",
+      "conclusion": "success",
+      "url": "https://github.com/maoyadongsh/siq-agent-security/actions/runs/34242906726/job/102117372192"
+    },
+    {
+      "name": "edge (stable, connectors/directory)",
+      "conclusion": "success",
+      "url": "https://github.com/maoyadongsh/siq-agent-security/actions/runs/34242906726/job/102117372179"
+    },
+    {
+      "name": "edge (stable, connectors/workbuddy)",
+      "conclusion": "success",
+      "url": "https://github.com/maoyadongsh/siq-agent-security/actions/runs/34242906726/job/102117372015"
+    },
+    {
+      "name": "edge (1.22, connectors/mcp)",
+      "conclusion": "success",
+      "url": "https://github.com/maoyadongsh/siq-agent-security/actions/runs/34242906726/job/102117371942"
+    },
+    {
+      "name": "edge (stable, connectors/mcp)",
+      "conclusion": "success",
+      "url": "https://github.com/maoyadongsh/siq-agent-security/actions/runs/34242906726/job/102117372128"
+    },
+    {
+      "name": "edge (stable, connectors/hermes)",
+      "conclusion": "success",
+      "url": "https://github.com/maoyadongsh/siq-agent-security/actions/runs/34242906726/job/102117372092"
+    },
+    {
+      "name": "edge (stable, connectors/dify)",
+      "conclusion": "success",
+      "url": "https://github.com/maoyadongsh/siq-agent-security/actions/runs/34242906726/job/102117372161"
+    },
+    {
+      "name": "edge (stable, connectors/openclaw)",
+      "conclusion": "success",
+      "url": "https://github.com/maoyadongsh/siq-agent-security/actions/runs/34242906726/job/102117372183"
+    },
+    {
+      "name": "edge (stable, connectors/kubernetes)",
+      "conclusion": "success",
+      "url": "https://github.com/maoyadongsh/siq-agent-security/actions/runs/34242906726/job/102117372056"
+    },
+    {
+      "name": "edge (stable, connectors/piagent)",
+      "conclusion": "success",
+      "url": "https://github.com/maoyadongsh/siq-agent-security/actions/runs/34242906726/job/102117372134"
+    },
+    {
+      "name": "edge (1.22, connectors/piagent)",
+      "conclusion": "success",
+      "url": "https://github.com/maoyadongsh/siq-agent-security/actions/runs/34242906726/job/102117371979"
+    },
+    {
+      "name": "edge (1.22, connectors/workbuddy)",
+      "conclusion": "success",
+      "url": "https://github.com/maoyadongsh/siq-agent-security/actions/runs/34242906726/job/102117372063"
+    },
+    {
+      "name": "runtime-security-toolchain",
+      "conclusion": "success",
+      "url": "https://github.com/maoyadongsh/siq-agent-security/actions/runs/34242906714/job/102117371797"
+    },
+    {
+      "name": "runtime-security-contracts",
+      "conclusion": "success",
+      "url": "https://github.com/maoyadongsh/siq-agent-security/actions/runs/34242906714/job/102117371485"
+    },
+    {
+      "name": "research-reproduction",
+      "conclusion": "success",
+      "url": "https://github.com/maoyadongsh/siq-agent-security/actions/runs/34242906752/job/102117371310"
+    }
+  ],
+  "all_passed": true
+}

--- a/docs/research/evidence/release-regression.json
+++ b/docs/research/evidence/release-regression.json
@@ -1,0 +1,22 @@
+{
+  "source_sha": "aefab111c7fcad9075c8f429f97c9eab519dcd22",
+  "local_packager_negative_tests": 3,
+  "local_source_archive_checks": "passed; full member hashes and required notices",
+  "hosted_ci": "31 required checks passed for exact integrated source",
+  "evidence": [
+    "release-ci.json",
+    "source-package-validation.json",
+    "research-rc.json"
+  ],
+  "unchanged_runtime_surfaces": [
+    "apps/agentshield",
+    "apps/secure-agent",
+    "apps/web",
+    "skills",
+    "packages/contracts",
+    "benchmarks/hackathon",
+    "benchmarks/runtime-security"
+  ],
+  "runtime_baseline": "d1277116e8291e72b09b0462a19d0268b68bf46c",
+  "binary_distribution": "not part of this source release"
+}

--- a/docs/research/evidence/remote-integration.json
+++ b/docs/research/evidence/remote-integration.json
@@ -1,0 +1,182 @@
+{
+  "observed_at": "2026-09-08T15:10:11.598462+00:00",
+  "pr": {
+    "number": 7,
+    "url": "https://github.com/maoyadongsh/siq-agent-security/pull/7",
+    "state": "closed",
+    "merged": true,
+    "merged_at": "2026-09-08T15:09:10Z",
+    "merge_commit_sha": "aefab111c7fcad9075c8f429f97c9eab519dcd22",
+    "head_sha": "e77fd75808e9e2b518a3b39d47cdf00bb5ae566e"
+  },
+  "main_sha": "aefab111c7fcad9075c8f429f97c9eab519dcd22",
+  "detected_license": "Apache-2.0",
+  "default_branch": "main",
+  "ci_before_merge": {
+    "observed_at": "2026-09-08T15:09:07.885203+00:00",
+    "pr": "https://github.com/maoyadongsh/siq-agent-security/pull/7",
+    "head_sha": "e77fd75808e9e2b518a3b39d47cdf00bb5ae566e",
+    "base_sha": "d1277116e8291e72b09b0462a19d0268b68bf46c",
+    "checks": [
+      {
+        "name": "web",
+        "conclusion": "success",
+        "url": "https://github.com/maoyadongsh/siq-agent-security/actions/runs/34242578200/job/102116234747"
+      },
+      {
+        "name": "agentshield",
+        "conclusion": "success",
+        "url": "https://github.com/maoyadongsh/siq-agent-security/actions/runs/34242578200/job/102116234616"
+      },
+      {
+        "name": "gitleaks",
+        "conclusion": "success",
+        "url": "https://github.com/maoyadongsh/siq-agent-security/actions/runs/34242578200/job/102116234911"
+      },
+      {
+        "name": "control-api",
+        "conclusion": "success",
+        "url": "https://github.com/maoyadongsh/siq-agent-security/actions/runs/34242578200/job/102116235080"
+      },
+      {
+        "name": "edge (1.22, connectors/directory)",
+        "conclusion": "success",
+        "url": "https://github.com/maoyadongsh/siq-agent-security/actions/runs/34242578200/job/102116235090"
+      },
+      {
+        "name": "edge (1.22, connectors/hermes)",
+        "conclusion": "success",
+        "url": "https://github.com/maoyadongsh/siq-agent-security/actions/runs/34242578200/job/102116234918"
+      },
+      {
+        "name": "edge (stable, edge/agent)",
+        "conclusion": "success",
+        "url": "https://github.com/maoyadongsh/siq-agent-security/actions/runs/34242578200/job/102116234892"
+      },
+      {
+        "name": "edge (1.22, connectors/kubernetes)",
+        "conclusion": "success",
+        "url": "https://github.com/maoyadongsh/siq-agent-security/actions/runs/34242578200/job/102116234933"
+      },
+      {
+        "name": "edge (1.22, edge/agent)",
+        "conclusion": "success",
+        "url": "https://github.com/maoyadongsh/siq-agent-security/actions/runs/34242578200/job/102116234993"
+      },
+      {
+        "name": "edge (1.22, connectors/dify)",
+        "conclusion": "success",
+        "url": "https://github.com/maoyadongsh/siq-agent-security/actions/runs/34242578200/job/102116235082"
+      },
+      {
+        "name": "edge (1.22, connectors/docker)",
+        "conclusion": "success",
+        "url": "https://github.com/maoyadongsh/siq-agent-security/actions/runs/34242578200/job/102116235011"
+      },
+      {
+        "name": "edge (stable, connectors/docker)",
+        "conclusion": "success",
+        "url": "https://github.com/maoyadongsh/siq-agent-security/actions/runs/34242578200/job/102116235034"
+      },
+      {
+        "name": "edge (1.22, connectors/openclaw)",
+        "conclusion": "success",
+        "url": "https://github.com/maoyadongsh/siq-agent-security/actions/runs/34242578200/job/102116234893"
+      },
+      {
+        "name": "edge (stable, connectors/process)",
+        "conclusion": "success",
+        "url": "https://github.com/maoyadongsh/siq-agent-security/actions/runs/34242578200/job/102116234882"
+      },
+      {
+        "name": "edge (1.22, connectors/systemd)",
+        "conclusion": "success",
+        "url": "https://github.com/maoyadongsh/siq-agent-security/actions/runs/34242578200/job/102116235016"
+      },
+      {
+        "name": "edge (1.22, connectors/process)",
+        "conclusion": "success",
+        "url": "https://github.com/maoyadongsh/siq-agent-security/actions/runs/34242578200/job/102116234930"
+      },
+      {
+        "name": "edge (stable, connectors/systemd)",
+        "conclusion": "success",
+        "url": "https://github.com/maoyadongsh/siq-agent-security/actions/runs/34242578200/job/102116234951"
+      },
+      {
+        "name": "edge (stable, connectors/directory)",
+        "conclusion": "success",
+        "url": "https://github.com/maoyadongsh/siq-agent-security/actions/runs/34242578200/job/102116235123"
+      },
+      {
+        "name": "edge (stable, connectors/workbuddy)",
+        "conclusion": "success",
+        "url": "https://github.com/maoyadongsh/siq-agent-security/actions/runs/34242578200/job/102116234950"
+      },
+      {
+        "name": "edge (1.22, connectors/mcp)",
+        "conclusion": "success",
+        "url": "https://github.com/maoyadongsh/siq-agent-security/actions/runs/34242578200/job/102116234909"
+      },
+      {
+        "name": "edge (stable, connectors/mcp)",
+        "conclusion": "success",
+        "url": "https://github.com/maoyadongsh/siq-agent-security/actions/runs/34242578200/job/102116235366"
+      },
+      {
+        "name": "edge (stable, connectors/hermes)",
+        "conclusion": "success",
+        "url": "https://github.com/maoyadongsh/siq-agent-security/actions/runs/34242578200/job/102116234875"
+      },
+      {
+        "name": "edge (stable, connectors/dify)",
+        "conclusion": "success",
+        "url": "https://github.com/maoyadongsh/siq-agent-security/actions/runs/34242578200/job/102116235050"
+      },
+      {
+        "name": "edge (stable, connectors/openclaw)",
+        "conclusion": "success",
+        "url": "https://github.com/maoyadongsh/siq-agent-security/actions/runs/34242578200/job/102116234844"
+      },
+      {
+        "name": "edge (stable, connectors/kubernetes)",
+        "conclusion": "success",
+        "url": "https://github.com/maoyadongsh/siq-agent-security/actions/runs/34242578200/job/102116235003"
+      },
+      {
+        "name": "edge (stable, connectors/piagent)",
+        "conclusion": "success",
+        "url": "https://github.com/maoyadongsh/siq-agent-security/actions/runs/34242578200/job/102116234922"
+      },
+      {
+        "name": "edge (1.22, connectors/piagent)",
+        "conclusion": "success",
+        "url": "https://github.com/maoyadongsh/siq-agent-security/actions/runs/34242578200/job/102116235056"
+      },
+      {
+        "name": "edge (1.22, connectors/workbuddy)",
+        "conclusion": "success",
+        "url": "https://github.com/maoyadongsh/siq-agent-security/actions/runs/34242578200/job/102116234841"
+      },
+      {
+        "name": "runtime-security-toolchain",
+        "conclusion": "success",
+        "url": "https://github.com/maoyadongsh/siq-agent-security/actions/runs/34242578019/job/102116234714"
+      },
+      {
+        "name": "runtime-security-contracts",
+        "conclusion": "success",
+        "url": "https://github.com/maoyadongsh/siq-agent-security/actions/runs/34242578019/job/102116234245"
+      },
+      {
+        "name": "research-reproduction",
+        "conclusion": "success",
+        "url": "https://github.com/maoyadongsh/siq-agent-security/actions/runs/34242578021/job/102116234168"
+      }
+    ],
+    "all_passed": true,
+    "review_exception": "single maintainer owner-authorized initial integration; administrator bypass of required independent approval, not failed checks"
+  },
+  "source_archive_kind": "unsigned source-only research prerelease",
+  "binary_release_status": "future separate acceptance"
+}

--- a/docs/research/evidence/research-rc.json
+++ b/docs/research/evidence/research-rc.json
@@ -1,0 +1,19 @@
+{
+  "observed_at": "2026-09-08T15:14:39.685239+00:00",
+  "scope": "source-only prerelease; no new binary native-launch claim",
+  "version": "research-v0.1.0-rc.1",
+  "source_sha": "aefab111c7fcad9075c8f429f97c9eab519dcd22",
+  "archive_sha256": "4a741a767faae5875ab2ec765b1c91d7f0eca076f5de67cff97ea59d1d4b1779",
+  "source_file_count": 2058,
+  "required_license_notice_count": 98,
+  "source_clean": true,
+  "source_checks": 31,
+  "source_checks_passed": true,
+  "archive_scan": "calibrated gitleaks passed on extracted source archive",
+  "fresh_download_verified": true,
+  "publication_receipt": "github-research-release.json",
+  "official_signature": false,
+  "private_state_bundled": false,
+  "startup_after_package": "not_applicable for source-only archive; hosted CI builds source and runs nine fixtures",
+  "binary_research_acceptance": "future separate scope"
+}

--- a/docs/research/maintenance-log.md
+++ b/docs/research/maintenance-log.md
@@ -1,3 +1,5 @@
 # Maintenance log
 
 2026-09-08: initialized research governance and security/private reporting, license/citation/third-party attribution, reproduction and community templates. Local nine-case UI and full fixed controls passed. Historical development-only signing material was separately reviewed; current local key differs. Hosted research CI, remote integration and future releases are tracked in operations-20260908.md. No external reproduction, archival DOI or paper review has been received in this cycle.
+
+2026-09-08 publication: PR #7 merged after 31 passing checks; final main checks also passed. Source prerelease research-v0.1.0-rc.1 published with three assets and fresh-download verification. Five contribution issues (#8–#12) published. Publication receipts/citation/task state are recorded separately after the immutable release. External archival and independent replication remain open.

--- a/docs/research/operations-20260908.md
+++ b/docs/research/operations-20260908.md
@@ -1,5 +1,7 @@
 # Research open-source operations — 2026-09-08
 
+Released source: `aefab111c7fcad9075c8f429f97c9eab519dcd22`; [source prerelease](https://github.com/maoyadongsh/siq-agent-security/releases/tag/research-v0.1.0-rc.1). All 31 required checks passed on this exact source. Three uploaded assets were freshly downloaded and verified, including all 2,058 archive members and 98 required license/notice files. Archive SHA256: `4a741a767faae5875ab2ec765b1c91d7f0eca076f5de67cff97ea59d1d4b1779`.
+
 Implementation branch: `codex/research-open-source-r1`, based on V5 documentation commit `e72e8b36a71ae7f7f1fecd587bbe6eb2353f24d2`. This is the research-cycle operations record; V5 competition source, artifacts, video and denominators remain frozen.
 
 ## Implemented
@@ -13,8 +15,12 @@ Implementation branch: `codex/research-open-source-r1`, based on V5 documentatio
 
 ## Remote integration and remaining work
 
-PR [#7](https://github.com/maoyadongsh/siq-agent-security/pull/7) carries this implementation. Five scoped contribution issues [#8–#12](https://github.com/maoyadongsh/siq-agent-security/issues?q=is%3Aissue+is%3Aopen) were created; Discussions and research topics are enabled. No outside researcher has been contacted or represented as a reproducer. Final remote commit, PR and CI results are recorded in evidence/remote-integration.json once available. The initial API operation records are [platform security](evidence/platform-security-readback.json), [main protection](evidence/branch-protection-readback.json) and [private reporting](evidence/private-reporting-readback.json).
+PR [#7](https://github.com/maoyadongsh/siq-agent-security/pull/7) carries this implementation. Five scoped contribution issues [#8–#12](https://github.com/maoyadongsh/siq-agent-security/issues?q=is%3Aissue+is%3Aopen) were created; Discussions and research topics are enabled. No outside researcher has been contacted or represented as a reproducer. Final remote commit, merged PR and CI are recorded in [remote integration](evidence/remote-integration.json), [release-source checks](evidence/release-ci.json) and [verified release receipt](evidence/github-research-release.json). The publication record is a later documentation change; it does not alter the immutable release source. The initial API operation records are [platform security](evidence/platform-security-readback.json), [main protection](evidence/branch-protection-readback.json) and [private reporting](evidence/private-reporting-readback.json).
 
 First release scope is an unsigned source-only research prerelease; see release-scope.md. A new binary research release still requires actual-payload SBOM/notice verification, a clean finalized source build and separate release acceptance. The old unsigned V5 RC is not silently republished as a licensed research binary. No publisher key or archival account is configured. No DOI, Zenodo upload, independent external reproduction, research-community response, new confirmatory experiment or paper submission is claimed.
 
 These remaining release/research milestones are tracked explicitly in the [71-task ledger](../open-source-research-tasks-20260908.md); repository setup does not complete the multi-month research programme.
+
+## Remaining scope
+
+The source-release engineering tasks are complete for this distribution. New binary packaging/native acceptance, a connected archival account/DOI, two external reproduction groups, controlled new experiments and paper submission remain outstanding. O-11.03 is blocked on an archival account; other experimental and recurring tasks retain their true status. The project is now licensed and publicly released, but the multi-month research programme is not declared complete.


### PR DESCRIPTION
Record the actual research-v0.1.0-rc.1 source prerelease, merged PR #7, exact-source 31 passing checks and fresh-download verification of all three assets. The archive contains 2,058 verified source files and 98 required license/notice files; it remains immutable at aefab111c7fcad9075c8f429f97c9eab519dcd22. No binaries or publisher signature are newly claimed.

Update the README release link and CFF version/date only after publication. The task ledger now records 47 completed tasks, one not applicable, two recurring tasks in progress and the archival-account blocker; the first two gates are met for source-release scope. Binary releases, independent external replication, DOI archival and the research programme remain separate work.

Validation: published-version CFF 1.2 schema, metadata/links, ledger checks and diff whitespace passed. This PR changes documentation/evidence only, and does not alter the released source archive or runtime. The sole-maintainer owner-authorized integration exception from GOVERNANCE.md applies after all 31 required checks pass; no independent review or historical DCO sign-off is fabricated.
