### PR TITLE
docs: Chinese-first research homepage with English version

### DIFF
--- a/AGENTSHIELD.md
+++ b/AGENTSHIELD.md
@@ -5,7 +5,7 @@
 **模型不判断 Skill 是否安全。** 裁决只由 `siq-agent-security` 二进制产出。产品说明见根 [`README.md`](./README.md)；本文件是本机操作与夹具步骤。企业控制面见 [`docs/control-plane.md`](./docs/control-plane.md)。本地模式只需 `serve`，不必启动 PostgreSQL / `:8600`。
 
 仓库：[`maoyadongsh/siq-agent-security`](https://github.com/maoyadongsh/siq-agent-security)  
-分支：`main`（本地产品与 Trusted Intent V2 核心已合入）。完整产品说明、能力边界和最新源码安装步骤以根 README 为准。
+分支：`main`（本地产品与 Trusted Intent V2 核心已合入）。研究演示与发布入口见根 README；本地源码构建及 Skill 接入步骤见下文。
 
 ## 三步（本机复现）
 
@@ -28,7 +28,7 @@ export SIQ_AGENT_SECURITY_STATE_DIR="${SIQ_AGENT_SECURITY_STATE_DIR:-$(pwd)/.sta
 
 浏览器打开 `http://127.0.0.1:47611`，在页面输入终端打印的**管理配对码**（5 分钟内单次有效）。适配器决策 token 在 `$SIQ_AGENT_SECURITY_STATE_DIR/token`（0600），不要贴进聊天或截图。当前是同 UID 桌面模式：不能防止同一用户下的 Agent 直接跑 CLI。
 
-把 Skill 装进 Hermes / OpenClaw / WorkBuddy 的步骤见根 README [快速开始](./README.md#快速开始)。以下在仓库根目录执行，并保持与 `serve` 相同的状态目录环境变量：
+以下是已构建本地二进制后，将 Skill 接入 Hermes / OpenClaw / WorkBuddy 的步骤。在仓库根目录执行，并保持与 `serve` 相同的状态目录环境变量：
 
 ```bash
 export SIQ_AGENT_SECURITY_BIN="$(pwd)/apps/agentshield/siq-agent-security"

--- a/README.en.md
+++ b/README.en.md
@@ -1,0 +1,156 @@
+# SIQ Agent Security
+
+**Reproducible runtime authorization and effect verification for Agent Skills.**
+
+[简体中文](README.md) · **English**
+
+[Quick start](#quick-start) · [Research and evidence](#research-and-evidence) · [Source release](https://github.com/maoyadongsh/siq-agent-security/releases/tag/research-v0.1.0-rc.1) · [Contributing](CONTRIBUTING.md) · [Security reports](SECURITY.md)
+
+SIQ Agent Security connects user authority, parameter provenance, tool execution and observed effects into an inspectable evidence chain. The Agent plans tasks and selects Skills. The SIQ runtime checks actions against trusted authority and determines task completion from independently collected effect evidence.
+
+The project serves researchers, Agent tool and adapter developers, and platform teams evaluating agent permission controls. The initial demonstration runs on ordinary Linux with deterministic model fixtures, without API keys, a GPU or the enterprise control plane.
+
+The first research version, **[research-v0.1.0-rc.1](https://github.com/maoyadongsh/siq-agent-security/releases/tag/research-v0.1.0-rc.1)**, is available as an **unsigned source prerelease**, with `SOURCE-INFO.json` and `SHA256SUMS`. It contains no newly compiled binaries or model weights. Checksums establish file integrity, not a publisher signature. Its source is fixed at [`aefab111`](https://github.com/maoyadongsh/siq-agent-security/commit/aefab111c7fcad9075c8f429f97c9eab519dcd22); later README and publication-record updates do not change that identity.
+
+## What you can verify
+
+Consider a task to analyze a repository, write a report and deliver it to a specified contact. The Agent dynamically selects research, report and delivery Skills. The demonstration exposes four observable outcomes:
+
+| Scenario | Check | Expected result |
+| --- | --- | --- |
+| Normal delivery | Task authority, trusted contact, file and receiver effects | `verified`: required effects have been verified |
+| MCP recipient injection | An untrusted tool result proposes a different recipient | `blocked`: the unauthorized action is stopped |
+| Same value, different provenance | Identical recipient values from a trusted database and MCP | Trusted path allowed; MCP path denied |
+| False tool success | The tool reports success, but the controlled receiver has no corresponding event | `incomplete`: a required effect is missing |
+
+These demonstrations use explicit model fixtures to drive real SIQ components. They verify specific security paths; they do not measure prompt-injection attack success rates against a real model.
+
+## How it works
+
+```mermaid
+flowchart LR
+    Task[User task] --> Agent[Agent planning and Skill selection]
+    Agent --> Proposal[Proposed tool call]
+    Authority[Trusted authority and parameter provenance] --> Runtime[SIQ runtime checks]
+    Proposal --> Runtime
+    Runtime -->|Execution allowed| Tool[Tool execution]
+    Runtime --> Receipts[Signed decision receipts]
+    Tool --> Observer[Independent effect collection]
+    Observer --> Completion[SIQ completion decision]
+```
+
+- **Before execution**: statically scan Skills and record capability requirements. Constrain actions with Grants, Intent, trusted Context and parameter provenance. Model output cannot create effective permissions.
+- **During execution**: check authority at integrated tool entry points and recheck held approvals before execution. Adapters associate actual calls with decisions.
+- **After execution**: record signed receipts and collect file or controlled-receiver effect evidence. Tool-reported success, observed effects and task completion are separate records.
+
+Ordinary Observation correlation and independent EffectEvidence establish different things. See the [technical report](docs/research/technical-report.md), [contracts](packages/contracts/README.md) and [security boundaries](#security-boundaries) for architecture and protocol details.
+
+## Quick start
+
+### 1. Run the demonstration without model keys
+
+The validated entry environment is Linux with Git, Go **1.26.6**, Python **3.12+**, and Node.js **22 / npm**. Initial dependency and toolchain installation needs network access. Use a fresh clone: the launcher refuses to overwrite existing demonstration state.
+
+```bash
+git clone https://github.com/maoyadongsh/siq-agent-security.git
+cd siq-agent-security
+
+bash scripts/hackathon/start.sh --mode test --port 47621
+bash scripts/hackathon/healthcheck.sh
+bash scripts/hackathon/pair.sh
+```
+
+The launcher installs locked Web dependencies and builds the local UI and Go binary. Open **http://127.0.0.1:47621/demo**, enter the one-time pairing code printed in your terminal, and select a scenario from the table above. Keep pairing codes and service state files on your machine.
+
+Pass `--mode test` explicitly: the launcher's default `demo` mode uses configured real models. To pin the first release, run `git switch --detach research-v0.1.0-rc.1` before starting.
+
+Stop this demonstration instance when finished:
+
+```bash
+bash scripts/hackathon/stop.sh
+```
+
+Before restarting, archive the instance's previous state as described in the [reproduction guide](REPRODUCIBILITY.md). That guide also covers occupied ports, pairing issues and environment diagnostics.
+
+### 2. Reproduce the fixed benchmark
+
+Install **uv** as well, then run these commands from the repository root. Use fresh state and output directories for every attempt.
+
+```bash
+(cd apps/control-api && uv sync --dev --locked)
+mkdir -p .tmp/research-bin
+GOTOOLCHAIN=go1.26.6 go -C apps/agentshield build \
+  -o "$PWD/.tmp/research-bin/siq-agent-security" ./cmd/agentshield
+
+apps/control-api/.venv/bin/python benchmarks/hackathon/run.py \
+  --binary .tmp/research-bin/siq-agent-security \
+  --state-root .tmp/my-research-controls \
+  --out .tmp/my-research-results/controls.json
+
+apps/control-api/.venv/bin/python benchmarks/hackathon/verify.py \
+  .tmp/my-research-results/controls.json \
+  --out .tmp/my-research-results/verification.json
+```
+
+The default cohort contains all **23 fixed control cases**. Check expectation violations and verifier results: `blocked` for an attack or `incomplete` for false tool success can be the correct outcome. Retain failed attempts and review reports against the [evidence export policy](docs/research/data-export-policy.md) before sharing. Do not upload private state directories.
+
+### 3. Optional: use real models
+
+The existing real-model demonstration uses **StepFun `step-3.7-flash` for remote planning** and **Ornith on DGX Spark for local analysis**. This path requires separate model, credential and hardware configuration. Run it separately from the key-free paths and report its results separately.
+
+Start with the [DGX deployment guide](deploy/dgx-spark/README.md), [private model configuration](docs/hackathon/step-plan.md) and [three-track reproduction guide](REPRODUCIBILITY.md). A local failure during confidential analysis must not automatically authorize fallback to a remote model.
+
+## Research and evidence
+
+These numbers describe specific archived runs, not guarantees for arbitrary environments or future versions.
+
+| Archived observation | Result | Evidence and scope |
+| --- | --- | --- |
+| Fixed control cases | **23/23** expectations satisfied | [Report and verification summary](docs/research/result-reproduction.md); controlled fixtures run during development |
+| Benign task completion | **5/5** | All benign tasks in the same control report |
+| Unsafe target materialization | **0/13** | Cases with a registered unsafe target; a different denominator from benign tasks |
+| Receipt and effect-envelope verification | **318** receipts, **20** effect envelopes | [Independent verification output](docs/research/evidence/reproduction-b/verification.json) |
+| Browser reproduction on ordinary Linux | **9/9** scenarios passed | [Hosted Ubuntu run](docs/research/evidence/reproduction-a/hosted-linux-identity.json); no GPU or model keys |
+| Released-source CI | **31** required checks passed | [Release-source record](docs/research/evidence/release-ci.json); source `aefab111` |
+
+Historical StepFun and Ornith benign-task cohorts each retain later **5/5** results, alongside earlier **4/5** failures in the [original benchmark report](docs/hackathon/benchmark-report.md). These small samples do not establish statistical guarantees and must not be pooled with fixed fixtures or later demonstrations. Hosted CI reproduction is not independent reproduction by an external researcher.
+
+Research entry points: [questions](docs/research/research-questions.md) · [dataset card](docs/research/dataset-card.md) · [evaluation protocol](docs/research/evaluation-protocol.md) · [claims and evidence](docs/research/claims-evidence.md). No published paper, DOI or independent artifact certification is currently claimed.
+
+## Components and integrations
+
+| Component | Responsibility | Entry point |
+| --- | --- | --- |
+| Secure Agent and research Skills | Task planning and dynamic research / report / delivery selection | [Agent guide](apps/secure-agent/README.md), [Skills](skills/) |
+| Local Go runtime | Admission, authorization, management API, signed receipts and effect verification | [Local operations](AGENTSHIELD.md), [development specification](docs/agentshield-dev-spec-v1.md) |
+| Runtime adapters | Specific tool entry points in Hermes, OpenClaw and CodeBuddy | [Adapters](adapters/runtime/), [capability matrix](docs/agentshield-capability-matrix-v1.md) |
+| Enterprise control plane | Multi-tenant inventory, evidence, policy approval and Edge coordination | [Control plane](docs/control-plane.md), [production runbook](docs/enterprise-production-runbook-v1.md) |
+| Edge and Connectors | Configuration, directory, framework, process, container and cluster collection | [Edge](edge/agent/), [Connectors](connectors/), [compatibility](docs/compatibility.md) |
+| Contracts and benchmarks | Cross-component data contracts, fixed corpus and evidence verification | [Contracts](packages/contracts/), [Agent benchmark](benchmarks/hackathon/README.md), [runtime benchmark](benchmarks/runtime-security/README.md) |
+
+The local demonstration does not require PostgreSQL, enterprise login or the enterprise API. Collection, tool blocking and native validation are tracked separately for each platform. An adapter's existence does not establish protection across all versions or execution paths. Consult the relevant runbook for production prerequisites and unverified scope.
+
+## Security boundaries
+
+- **No same-UID isolation**: desktop mode cannot prevent a malicious process under the same OS user from reading keys or modifying state. The Python ToolGateway is not an OS sandbox.
+- **Limited integration coverage**: authorization checks cover correctly integrated execution paths. Source registration and sensitivity classification still depend on trusted operators.
+- **Scoped effect evidence**: file and controlled-receiver observations do not prove delivery across arbitrary external SaaS systems. Missing or conflicting evidence cannot be counted as success.
+- **Limited experimental claims**: a small fixed corpus and model fixtures do not establish universal prompt-injection protection, full semantic provenance or production security certification. Cross-compilation is not native validation on every platform.
+
+See the [threat model](docs/threat-model.md), [capability matrix](docs/agentshield-capability-matrix-v1.md) and [dataset card](docs/research/dataset-card.md). Report unpatched vulnerabilities through the private channel in [SECURITY.md](SECURITY.md).
+
+## Contributing and next steps
+
+Contributions are welcome for ordinary Linux reproduction, same-value provenance explanations, fixture diagnostics, metric corrections and negative cases with documented origins. Read [CONTRIBUTING.md](CONTRIBUTING.md), then choose a [starter task](docs/research/community-backlog.md), [Issue](https://github.com/maoyadongsh/siq-agent-security/issues) or [Discussion](https://github.com/maoyadongsh/siq-agent-security/discussions).
+
+Next priorities are long-term archival and a DOI, independent external reproduction, new experiments with protocols defined in advance, and paper/artifact review. A new binary research release still needs separate distribution and native acceptance checks. Actual progress is recorded in the [operations report](docs/research/operations-20260908.md) and [task ledger](docs/open-source-research-tasks-20260908.md). Contributions follow the [DCO](DCO) and [governance rules](GOVERNANCE.md); community participation follows the [code of conduct](CODE_OF_CONDUCT.md).
+
+## Licensing, citation and historical material
+
+Project-owned software uses **[Apache-2.0](LICENSE)**. Explicitly listed original research documents use **[CC BY 4.0](LICENSES/README.md)**. Third-party code, patches and fonts retain their own licenses; see the [scope mapping](LICENSES/scope.json) and [third-party notices](THIRD_PARTY_NOTICES.md). Model weights and external API services are outside the project license grant.
+
+Use **[CITATION.cff](CITATION.cff)** to cite the software, and record the version, commit and corpus digest actually used. The [citation guide](docs/research/citation-guide.md) explains source and research-material references.
+
+[Competition demonstration](HACKATHON.md) · [V5 frozen snapshot](docs/hackathon/final-submission-state.md) · [Research technical report](docs/research/technical-report.md) · [Development conventions](AGENTS.md) · [Continuous integration](https://github.com/maoyadongsh/siq-agent-security/actions)
+
+The competition snapshot retains its original source, artifacts, video and experimental denominators. Research releases and subsequent documentation updates carry their own identity records.

--- a/README.md
+++ b/README.md
@@ -1,587 +1,156 @@
 # SIQ Agent Security
 
-研究入口：[研究指南](docs/research/README.md) · [无模型密钥复现](REPRODUCIBILITY.md) · [引用](CITATION.cff) · [贡献](CONTRIBUTING.md) · [安全报告](SECURITY.md)。自有代码采用 [Apache-2.0](LICENSE)，明确列出的原创研究文档采用 [CC BY 4.0](LICENSES/README.md)，第三方许可保留。
+**为 Agent Skills 提供可复现的运行时授权与效果核验。**
 
-首个[研究源码预发布 research-v0.1.0-rc.1](https://github.com/maoyadongsh/siq-agent-security/releases/tag/research-v0.1.0-rc.1)已上线（未签名，附来源清单与校验和）。
+**简体中文** · [English](README.en.md)
 
-本轮研究开源操作与验证见[实施记录](docs/research/operations-20260908.md)。比赛 V5 材料保留为原始冻结快照；新实验使用独立身份。当前没有论文、DOI 或独立复现认证。
+[快速开始](#快速开始) · [研究与证据](#研究与证据) · [源码发布](https://github.com/maoyadongsh/siq-agent-security/releases/tag/research-v0.1.0-rc.1) · [贡献](CONTRIBUTING.md) · [安全报告](SECURITY.md)
 
-## Secure Runtime for Agent Skills
+SIQ Agent Security 将用户授权、参数来源、工具执行和实际效果连接成可检查的证据链。Agent 负责规划任务和选择 Skills，SIQ 运行时依据受信授权检查动作，并根据独立采集的效果证据判断任务完成情况。
 
-> Agent Skills define what agents can do. SIQ defines what they are allowed to do.
+项目面向研究者、Agent 工具与适配器开发者，以及评估智能体权限治理的平台团队。首次体验可以在普通 Linux 上使用确定性模型夹具，不需要 API 密钥、GPU 或企业控制面。
 
-StepFun plans the task. NVIDIA DGX Spark keeps sensitive analysis local. SIQ independently authorizes consequential actions and verifies their scoped effects.
+首个研究版本 **[research-v0.1.0-rc.1](https://github.com/maoyadongsh/siq-agent-security/releases/tag/research-v0.1.0-rc.1)** 已发布：**源码预发布，未签名**，附 `SOURCE-INFO.json` 和 `SHA256SUMS`。该版本不包含新编译的二进制或模型权重；摘要校验用于确认文件完整性，不代表发布者签名。发布源码固定在 [`aefab111`](https://github.com/maoyadongsh/siq-agent-security/commit/aefab111c7fcad9075c8f429f97c9eab519dcd22)，后续首页与发布回执更新不改变这一身份。
 
-分析仓库、生成报告并交付给指定联系人：Agent 动态选择 Skills，SIQ 验证权限与参数来源，独立效果证据决定任务是否完成。
+## 可以验证什么
 
-```text
-User → StepFun Planning → Dynamic Agent Skills → DGX Local Analysis
-     → SIQ Runtime Authorization → Tools → EffectEvidence → Completion
-```
+以“分析仓库、生成报告并交付给指定联系人”为例，Agent 动态选择研究、报告和交付 Skills。演示包含以下四种可观察结果：
 
-运行 `./scripts/hackathon/start.sh`，再运行 `./scripts/hackathon/healthcheck.sh`。
-详见 [Demo / Quick Start](HACKATHON.md)、[唯一提交状态](docs/hackathon/final-submission-state.md)、[六主题证据索引](docs/hackathon/evidence/INDEX.md)。
-
-**V5 历史比赛冻结：** 源码、CI、四平台 RC、DGX/StepFun 链路和视频的原始核验范围见[最终清单](docs/hackathon/FINAL-SUBMISSION-CHECKLIST.md)。其签名和赛事上传状态属于当时快照；当前研究开源与仓库治理状态见上方实施记录。
-
-SIQ Agent Security 将“谁授权、允许访问什么、可以产生哪些效果、实际发生了什么”连接成一条可检查的安全链。它以可安装的 Skill 作为交互入口，以本地 Go 程序执行确定性的授权判断，通过运行时适配器接入工具调用，并以签名回执记录决策与结果关联。企业控制面进一步提供多环境资产盘点、证据管理、策略审批和执行协调。
-
-项目面向使用 Hermes、OpenClaw、WorkBuddy / CodeBuddy 等智能体的开发者、平台团队与安全团队，也面向在 NVIDIA DGX Spark 等设备上部署私有 AI 工作流的组织。
-
-[快速开始](#快速开始) · [核心能力](#核心能力) · [技术前沿与项目创新](#技术前沿与项目创新) · [商业价值](#商业价值与应用场景) · [安全边界](#安全边界与当前限制) · [开发与验证](#开发与验证)
-
-[产品介绍](https://maoyadongsh.github.io/siq-agent-security/) · [架构全景](https://maoyadongsh.github.io/siq-agent-security/architecture.html) · [CI](https://github.com/maoyadongsh/siq-agent-security/actions/workflows/ci.yml) · [发布版本](https://github.com/maoyadongsh/siq-agent-security/releases)
-
-> **当前比赛状态：** 以[唯一提交状态](docs/hackathon/final-submission-state.md)为准；下文早期组件验证与路线图保留其历史适用范围。
-
-## 为什么需要 SIQ Agent Security
-
-智能体可以安装 Skill、读取文件、调用 MCP 服务、运行命令和向外部系统提交数据。它的风险随行动能力扩大：一段来自网页、文档或工具结果的恶意指令，可能把一个正常任务转变成越权操作。
-
-传统应用可以围绕固定接口进行授权；智能体会在执行过程中组合工具、构造参数和选择资源。因此，安全检查需要覆盖三个不同问题：
-
-| 检查层次 | 需要回答的问题 | SIQ 的处理方式 |
+| 场景 | 关键检查 | 预期结果 |
 | --- | --- | --- |
-| 能力进入工作流之前 | 这个 Skill 包含什么代码、指令和权限需求？ | 静态准入扫描、内容摘要、能力声明与 Skill Card |
-| 每次行动之前 | 当前主体在这个任务中，是否有权对这个资源执行此操作？ | Grant、签名 Intent、工具效果与参数约束的联合检查 |
-| 行动及变更之后 | 哪项授权导致了决策？结果属于哪个动作？记录是否完整？ | 动作标识、Decision / Observation 关联、签名回执与企业审计 |
+| 正常交付 | 任务授权、受信联系人、文件与接收端效果 | `verified`：要求的效果已核验 |
+| MCP 收件人注入 | 不可信工具结果提出更换收件人 | `blocked`：不允许的动作被阻止 |
+| 同值不同来源 | 相同收件人值分别来自可信数据库与 MCP | 可信路径允许；MCP 路径拒绝 |
+| 工具伪成功 | 工具返回成功，但受控接收端没有对应事件 | `incomplete`：缺少所需效果 |
 
-例如，用户只授权助手读取客户 A 的资料并生成本地报告。即使助手拥有文件工具，也不应因此读取客户 B 的资料；即使拥有网络工具，也不应因此把报告发往任意地址。SIQ 将这些约束表示为可执行的数据合同，并在已经接入的工具入口检查。
+这些演示使用显式模型夹具驱动真实 SIQ 组件。它们验证指定安全路径，不是实模型遭受提示注入时的攻击成功率测量。
 
-项目遵循一项核心原则：**模型可以提出操作和解释结果；授权依据来自受信管理流程，最终权限判断由程序执行。** 当前桌面部署的操作系统边界及例外见[安全边界](#安全边界与当前限制)。
-
-## 产品形态与系统架构
-
-同一仓库提供两种运行方式，复用 JSON Schema、证据语义与检测规则，但各自拥有独立运行入口。
-
-| 维度 | 本地模式 | 企业控制面 |
-| --- | --- | --- |
-| 使用对象 | 单台开发机、个人助手、本地 AI 主机 | 多团队、多环境的智能体治理 |
-| 主要能力 | Skill 准入、Grant、Intent V2、工具决策、签名回执 | 资产与证据台账、权限分析、策略审批、Edge 任务与执行协调 |
-| 运行组件 | `siq-agent-security serve`，Go 单文件内嵌控制台 | React 控制台、FastAPI、Worker、PostgreSQL、Edge / Connector |
-| 身份入口 | 一次性配对建立本地管理会话 | 生产使用 OIDC / JWKS 与租户权限检查 |
-| 数据存储 | 本机状态目录、签名记录与恢复标记 | PostgreSQL，使用 Alembic 管理迁移 |
-| 前端代码 | `apps/web/src/local/` | `apps/web/src/` 中的企业入口 |
-| 本地开发服务 | `127.0.0.1:47611` | API `127.0.0.1:8600`，前端由 Vite 提供 |
-
-**安装 Skill 后对应的是本地控制台。** `apps/web` 是一个前端工程，包含本地和企业两套应用入口；产品介绍站用于展示项目。运行本地模式无需启动企业 API、PostgreSQL 或企业登录服务。
+## 工作方式
 
 ```mermaid
-flowchart TB
-    Human[操作者确认授权] --> Console[本地控制台 / 管理 API]
-    Skill[SIQ Skill：交互与操作指引] --> Agent[业务 Agent]
-    Candidate[候选 Skill / 配置] --> Admission[静态准入与能力提取]
-    Admission --> Console
-    Console --> Authority[签名 Grant / Intent / 会话绑定]
-    Agent --> Adapter[运行时适配器]
-    Adapter --> Gate[本地决策引擎]
-    Authority --> Gate
-    Gate --> Decision[allow / deny / hold / redact]
-    Decision --> Adapter
-    Adapter --> Tool[获准的工具调用]
-    Tool --> Observe[结果关联与 Observation]
-    Gate --> Receipts[签名回执链]
-    Observe --> Receipts
-    Receipts --> Console
-
-    Connectors[只读 Connector] --> Edge[Edge Agent]
-    Edge --> Control[企业 Control API / Worker]
-    EnterpriseUI[企业控制台] --> Control
-    Control --> DB[(PostgreSQL)]
-    Control --> Backend[执行后端适配 / 读回验证]
+flowchart LR
+    Task[用户任务] --> Agent[Agent 规划与选择 Skills]
+    Agent --> Proposal[工具调用提议]
+    Authority[受信授权与参数来源] --> Runtime[SIQ 运行时检查]
+    Proposal --> Runtime
+    Runtime -->|允许执行| Tool[工具执行]
+    Runtime --> Receipts[签名决策回执]
+    Tool --> Observer[独立效果采集]
+    Observer --> Completion[SIQ 完成判定]
 ```
 
-本地链路依赖平台工具钩子执行决策；Observation 当前记录的是适配器上报结果。企业链路与本地链路共享合同，现有本地 `sync` 主要上传盘点证据，尚未形成企业签发 Intent 到本地执行的完整分发链。
+- **执行前**：静态扫描 Skill，记录能力需求；通过 Grant、Intent、受信 Context 和参数来源约束动作。模型输出不能创建有效权限。
+- **执行时**：在已接入的工具入口检查授权；需要审批的动作在执行前重新核验。适配器将实际调用与决策关联。
+- **执行后**：记录签名回执，采集文件或受控接收端的效果证据。工具自报成功、已观察效果和任务完成状态分别记录。
 
-## 核心能力
-
-### 1. 资产发现与 Skill 准入
-
-盘点平台配置、Agent、Skill 与 MCP 配置引用。企业 Edge 通过 11 个 Connector 覆盖 Hermes、OpenClaw、Directory、Dify、PiAgent、WorkBuddy、MCP、Docker、Process、systemd 与 Kubernetes；采集能力和运行时阻断能力分别登记。
-
-准入过程静态读取候选内容，不执行脚本、不导入被扫描模块。扫描范围、文件数量、体积、深度和特殊文件受到限制，输出三类结论：
-
-| 结论 | 含义 | 后续处理 |
-| --- | --- | --- |
-| `quarantine` | 命中隐藏指令、欺骗、凭据外传或完整性失败等隔离条件 | 停止安装；CLI 退出码为 `3` |
-| `admit_with_conditions` | 存在工具、出网、文件写入等需要授权的能力声明 | 审阅权限，起草 Grant |
-| `admit` | 当前规则与输入范围内未触发上述条件 | 仍需遵守后续授权与运行时检查 |
-
-`allowed-tools`、网络访问和软件安装属于需要治理的能力需求，不单凭它们认定 Skill 恶意。扫描结论带有规则及证据，可以回溯到具体发现；通过扫描不代表对未知攻击免疫。
-
-### 2. 最小权限与人工管理流程
-
-Grant 将能力需求转化为可审阅的权限范围，支持起草、批准、部署、拒绝和撤销。批准挑战绑定待批准内容与版本，并使用一次性 nonce；过期、重复或对象已变化的挑战不能继续批准。
-
-本地管理会话和适配器决策 token 分权：决策客户端不能调用 Intent 签发、批准等管理接口。服务持有单写者锁，运行期间的 Grant 修改通过控制台或管理 API 完成；离线 CLI 不与服务竞争写入状态。
-
-权限事实保留五种语义：`declared` 声明、`inferred` 推断、`observed` 观察、`effective` 后端读回确认、`unknown` 未知。每种状态都有证据要求，策略已下发本身不会提升为 `effective`。
-
-### 3. Trusted Intent V2：任务级授权
-
-Grant 描述已授予的能力，Intent 进一步约束这些能力在**当前任务**中的使用范围。V2 包含主体、Agent、任务、工具、效果、资源、参数、有效期与发行信息，由管理端校验后签名，并绑定到确定的平台、Agent 和会话。
-
-在 `block` 模式下，对于绑定 V2 的会话，授权判断可以概括为：
-
-```text
-允许执行 = Grant 允许
-        ∩ Intent 签名、身份、绑定与时效有效
-        ∩ 工具、效果、资源、参数满足约束
-        ∩ 运行时安全状态允许
-```
-
-实现支持：
-
-- **可信授权解析：** 从本地不可变签名 Store 读取 Intent；拒绝以请求内嵌 Intent 创建授权，客户端主体与任务提示仅用于一致性检查。
-- **工具与效果分离：** 区分工具名称和 `file.read`、`file.write`、`network.request` 等效果；Shell 带有 `unknown` 效果，绑定 V2 时采取保守拒绝策略。
-- **结构化资源约束：** 对文件路径、网络 host / IP 和消息收件人进行规范化与匹配，识别相邻目录前缀混淆和多个参数别名。
-- **参数约束：** 使用 JSON Pointer 定位嵌套字段及数组元素，支持 `equals`、`one_of`、`prefix`、`suffix`、`regex` 等操作；资源域另有对应约束。
-- **固定绑定与防降级：** 已绑定会话不能通过省略字段、替换任务提示或重启服务退回未绑定授权路径。
-
-`purpose` 是任务说明文本，不由在线模型解释为额外权限。V2 当前通过管理 API 使用，完整的可视化任务授权流程仍待完善。默认配置及 `warn` / `audit_only` 的实际语义见[任务授权使用说明](#使用-trusted-intent-v2)。
-
-### 4. 运行时决策、动作关联与恢复
-
-适配器将工具调用映射为统一动作信封。引擎综合授权、敏感信息、会话污点和风险组合，返回 `allow`、`deny`、`hold` 或 `redact`。平台对等待审批和参数改写的支持程度决定最终映射方式。
-
-每个动作由服务端分配 `action_id`、`task_seq` 和 `parent_action_id`。结果上报必须关联合法的前置 Decision，并匹配平台、会话、Agent、工具及调用标识。同一结果重复上报复用已有回执；冲突结果被拒绝；拒绝决策和未经本地批准的 hold 不能产生获准执行的 Observation。
-
-签名链在重启时用于恢复绑定、动作关联和相关运行状态。已有并发、重复上报、任务边界和进程强杀恢复测试；动作窗口有界，不能通过清空安全状态来把旧会话伪装成干净会话。
-
-### 5. 企业资产治理与执行协调
-
-企业控制面提供候选资产确认、证据回链、权限事实、风险处置、策略变更审批、部署与回滚状态，以及 Edge 注册、心跳、任务租约和回执处理。
-
-关键实现包括租户身份派生、对象级权限检查、职责分离、业务变化与审计 / Outbox 同事务、Edge 凭据在线吊销校验、签名任务与证据协议。生产配置要求 PostgreSQL 和外部身份验证，开发身份头与 SQLite 仅用于显式开发模式。
-
-详见[企业控制面](./docs/control-plane.md)、[合同目录](./packages/contracts/README.md)与[生产运行手册](./docs/enterprise-production-runbook-v1.md)。实际客户环境的身份接入、网络入口和执行验证需要单独验收。
-
-## 技术前沿与项目创新
-
-项目的技术主线是将智能体的动态行动约束转化为**可执行授权合同、可恢复状态和可检查证据**。以下是当前实现的工程特点与后续研究方向，不构成“全球首创”或论文效果复现声明。
-
-### 从工具允许列表推进到任务和参数授权
-
-同一个工具可以用于完全不同的业务目的。SIQ 在工具权限之上增加签名任务合同，把主体、资源、参数和效果共同纳入决策，使“允许使用文件工具”能够进一步收敛为“本次只允许读取指定目录”。授权验证不依赖在线模型再次判断自然语言意图。
-
-### 将授权来源与调用方输入分开
-
-在提示注入场景中，调用参数、工具描述和模型解释都可能受到污染。SIQ 的管理 API 与决策 API 分权，Intent 通过不可变签名 Store 解析；模型自报的主体或来源引用不会因此成为授权依据。
-
-这一设计与 MCP 对工具元数据的信任边界相容：MCP 规范要求谨慎对待来自不可信服务器的工具 annotations。[MCP Tools 规范](https://modelcontextprotocol.io/specification/2025-06-18/server/tools)。本项目当前已实现 MCP 配置发现，完整 MCP 协议中介仍在规划中。
-
-### 将动作身份、结果关联与故障恢复一并设计
-
-只保存一条工具日志无法解决重复回调、迟到结果、重启和跨任务混淆。SIQ 将动作身份与授权摘要纳入签名链，结合幂等结果关联和恢复逻辑，使审计记录能够回答“这份结果属于哪次获准动作”。签名验证覆盖记录完整性；业务效果是否真实发生需要额外证据。
-
-### 通过证据描述权限的实际状态
-
-权限声明、管理批准、策略部署、后端读回与实际执行验证是不同事实。SIQ 通过五态权限和能力矩阵将这些差别呈现给操作者，避免用一个“已启用”状态掩盖接入范围及验证缺口。
-
-### 与 Skill 供应链治理及沙箱形成互补
-
-NVIDIA Verified Skills 提供扫描、评测、签名和 Skill Card，覆盖能力发布与进入工作流的治理。[NVIDIA 官方说明](https://docs.nvidia.com/skills)。SIQ 保留安装前准入，并进一步连接用户授权、运行时动作和本地回执。
-
-OpenShell 可作为执行隔离与策略后端；SIQ 通过适配器协调能力探测、策略操作和读回。其官方策略区分静态与动态配置，接入时仍需按本仓实际版本和探针结果验证。[OpenShell 策略文档](https://docs.nvidia.com/openshell/sandboxes/policies)。
-
-### 实验性参数来源与效果验证
-
-参数值相同不代表授权相同。Intent V3 可以要求某个高影响参数来自已注册的可信签发者：相同路径由 USER 签发时可通过，由 MCP/untrusted 提供时可被拒绝。来源图绑定任务、会话、Agent、内容摘要和期限；普通转换不提升信任，混合聚合保留最低父信任。当前验证覆盖显式来源关系，不追踪模型内部因果链。
-
-EffectEvidence 将工具自报结果与独立采样材料分开。文件 observer 提供 `host_independent/partial` 证据；受控网络 oracle 验证实际接收端点。Completion 根据签名要求、材料及历史授权输出 `verified`、`incomplete`、`conflicting` 或 `unknown`。这些是实验性组件能力，不能等同任意平台的 OS 隔离或通用业务正确性证明。具体控制与残余风险见[威胁模型 T27–T35](./docs/threat-model.md)。
-
-## 技术难点与工程取舍
-
-| 难点 | 当前处理方式 | 仍需注意的边界 |
-| --- | --- | --- |
-| 不可信输入进入授权链 | 管理 / 决策接口分权；不可变签名 Intent；固定会话绑定 | 同 UID 进程仍可能接触本地状态；受管 Linux 隔离待实现 |
-| 参数解释不一致导致越权 | 路径与 host 规范化、JSON Pointer、精确 JSON 数值比较、共享匹配语料 | 路径词法匹配无法证明文件系统对象及符号链接的实际目标 |
-| 工具名称掩盖副作用 | Tool / Effect 分离；未知效果保守拒绝 | 任意 Shell 的全部效果无法仅由命令字符串完整推导 |
-| 状态安全与性能同时满足 | 确定性绑定 ID 直接定位目标，每次读取仍验签；动作关联缓存有界 | 微基准之外仍需整体 HTTP、落盘和长期运行负载验证 |
-| 崩溃中断多文件写入 | 单写者、版本比较、提交恢复标记和幂等重放 | 已覆盖的故障模型不等于任意文件系统损坏下均可自动恢复 |
-| 平台钩子差异 | 薄适配器统一 pre/post、调用 ID 和断连行为；按能力登记状态 | 框架安装入口、审批、参数改写与后置钩子覆盖不同 |
-| 跨语言签名和合同演进 | 版本化 Schema、固定摘要 / Ed25519 向量、历史回执兼容测试 | Python 合同验证不等于另一个完整 V2 授权引擎 |
-| 采集有用证据又避免泄密 | 摘要、引用、脱敏与长度预算；导出投影单独签名 | 普通哈希不提供加密机密性，低熵值仍需限制访问 |
-
-本地裁决核心只依赖 Go 标准库，便于单文件构建和离线分发；前端在构建时嵌入，运行裁决不依赖 Python 服务。企业 API 使用 Python / FastAPI，前端使用 React / TypeScript / Vite，各组件通过显式合同协作。
-
-## 商业价值与应用场景
-
-SIQ 的价值在于帮助组织把智能体从个人试用推进到可管理的业务试点：建立资产归属、限制权限范围、保留审查依据，并降低框架接入和事故排查的重复工作。
-
-| 用户与场景 | 实际问题 | 可交付价值 | 适合在试点中衡量的指标 |
-| --- | --- | --- | --- |
-| 开发者与小团队 | Skill 来源不明、授权粗放、工具调用难追溯 | 本地准入、权限审阅与工具回执 | 安装成功率、误阻断率、排查耗时 |
-| 企业 AI 平台团队 | Agent 分散在框架、主机与容器中 | 多 Connector 资产发现与统一证据台账 | 资产覆盖率、未知权限比例、重复接入工作量 |
-| 安全与审计团队 | 权限变更和执行记录缺少关联 | 审批、部署、回执与证据回链 | 证据完整率、审计准备耗时、漂移处置时长 |
-| 私有部署与本地 AI 客户 | 业务资料与模型运行在客户环境 | 本地决策及存储，按需上传脱敏盘点证据 | 数据外传范围、任务完成率、额外运行延迟 |
-| 智能体应用与集成服务商 | 每个客户重复建设授权和审计功能 | 可复用合同、适配器和执行协调组件 | 新框架接入周期、场景复用率、交付维护成本 |
-
-可探索的商业交付路径是：**单机开发者工具 → 受控企业 PoC → 多环境治理与持续运维服务**。本地部署降低首次验证门槛，企业控制面承接组织级审批与运营；客户可以保留原有模型、身份系统和业务平台。
-
-这些是商业价值假设与验证方向。仓库没有据此宣称已获得客户收入、确定的成本节省比例或第三方安全认证。正式交付范围应由实际支持矩阵、部署环境和验收指标确定。
+普通 Observation 的结果关联与独立 EffectEvidence 的效果核验具有不同证明范围。架构、合同和方法细节见[技术报告](docs/research/technical-report.md)、[合同目录](packages/contracts/README.md)与[安全边界](#安全边界)。
 
 ## 快速开始
 
-### 环境要求
+### 1. 启动无需模型密钥的演示
 
-| 依赖 | 用途 |
-| --- | --- |
-| Git、Go 1.22+（兼容下限）；安全构建使用已验证的 Go 1.26.6 | 获取源码并构建本地程序 |
-| Node.js 22、npm | 从当前前端源码构建完整本地控制台；使用完整发布二进制时无需 Node |
-| Python 3、OpenSSL 3 | Skill 安装脚本校验清单签名、内容哈希及二进制 |
-| 支持工具钩子的 Agent 平台 | 运行时接入；只体验控制台和静态扫描时可以暂不安装 |
-
-以下命令适用于 Linux / macOS 的 POSIX Shell，建议先在独立状态目录试用。Windows 有独立 PowerShell 安装脚本，运行时支持范围见[平台矩阵](#平台适配与-dgx-spark-验证)。
-
-### 1. 构建当前 main 和本地前端
+已验证的入门环境为 Linux；准备 Git、Go **1.26.6**、Python **3.12+**、Node.js **22 / npm**。首次安装依赖和工具链需要联网。请使用新克隆的目录：启动器会拒绝覆盖已有演示状态。
 
 ```bash
 git clone https://github.com/maoyadongsh/siq-agent-security.git
 cd siq-agent-security
-git switch main
-export SIQ_REPO_ROOT="$(pwd)"
 
-npm --prefix apps/web ci
-npm --prefix apps/web run build:local
-
-go -C apps/agentshield build -trimpath -ldflags "-s -w" \
-  -o siq-agent-security ./cmd/agentshield
-
-export SIQ_AGENT_SECURITY_BIN="$SIQ_REPO_ROOT/apps/agentshield/siq-agent-security"
-"$SIQ_AGENT_SECURITY_BIN" version
+bash scripts/hackathon/start.sh --mode test --port 47621
+bash scripts/hackathon/healthcheck.sh
+bash scripts/hackathon/pair.sh
 ```
 
-`build:local` 将静态资源写入 Go 的 embed 目录，因此应在 Go 构建之前运行。源码构建默认版本为 `0.0.0-dev`，避免把新代码误标为旧 Release。企业前端由 `npm run build` 单独构建到 `apps/web/dist`。
+启动器会安装 Web 锁定依赖、构建本地界面和 Go 程序。打开 **http://127.0.0.1:47621/demo**，输入终端给出的一次性配对码，再选择上表中的场景。配对码和服务状态文件应留在本机。
 
-### 2. 启动本地控制台
+`--mode test` 必须显式给出：启动器默认的 `demo` 模式会使用配置的真实模型。需要固定首发源码时，在启动前执行 `git switch --detach research-v0.1.0-rc.1`。
+
+体验完成后停止这个演示实例：
 
 ```bash
-export SIQ_AGENT_SECURITY_STATE_DIR="$HOME/.local/state/siq-agent-security-demo"
-"$SIQ_AGENT_SECURITY_BIN" serve --port 47611 --mode block
+bash scripts/hackathon/stop.sh
 ```
 
-打开 **http://127.0.0.1:47611**，在页面输入终端显示的管理配对码。配对码五分钟内单次有效，管理凭据保存在浏览器内存中；刷新后需要重新建立管理会话时，重启 `serve` 获取新码。
+再次启动前，需要先按[复现指南](REPRODUCIBILITY.md)归档该实例的旧状态。端口冲突、配对问题和环境诊断也见该指南。
 
-状态目录包含签名密钥、适配器 token 和审计历史。后续命令及平台进程必须使用同一状态目录；不要把配对码、token、私钥或整个状态目录放进聊天、录屏和代码仓库。
+### 2. 复现固定基准
 
-本地页面包括概览、智能体资产、权限、风险、Grant、回执、运行绑定和设置。启动服务与打开页面只建立管理入口；完成适配器接入后，平台工具调用才会经过门禁。
-
-### 3. 安装 Skill 与运行时适配器
-
-另开终端，进入仓库根目录并设置与服务一致的环境变量。以下以 Hermes 为例：
+额外准备 **uv**，从仓库根目录运行。每次尝试使用新的状态目录和输出目录。
 
 ```bash
-export SIQ_REPO_ROOT="$(pwd)"
-export SIQ_AGENT_SECURITY_BIN="$SIQ_REPO_ROOT/apps/agentshield/siq-agent-security"
-export SIQ_AGENT_SECURITY_STATE_DIR="$HOME/.local/state/siq-agent-security-demo"
-export SIQ_AGENT_SECURITY_STAGE_DIR="$HOME/.cache/siq-agent-security-stage"
+(cd apps/control-api && uv sync --dev --locked)
+mkdir -p .tmp/research-bin
+GOTOOLCHAIN=go1.26.6 go -C apps/agentshield build \
+  -o "$PWD/.tmp/research-bin/siq-agent-security" ./cmd/agentshield
 
-mkdir -p "$HOME/.hermes/skills"
-# 若目标已经存在，先核对已有安装，再决定更新方式。
-ln -s "$SIQ_REPO_ROOT/skills/siq-agent-security" \
-  "$HOME/.hermes/skills/siq-agent-security"
+apps/control-api/.venv/bin/python benchmarks/hackathon/run.py \
+  --binary .tmp/research-bin/siq-agent-security \
+  --state-root .tmp/my-research-controls \
+  --out .tmp/my-research-results/controls.json
 
-skills/siq-agent-security/scripts/bootstrap.sh
-skills/siq-agent-security/scripts/adapter.sh hermes
-"$SIQ_AGENT_SECURITY_BIN" adapter status hermes
+apps/control-api/.venv/bin/python benchmarks/hackathon/verify.py \
+  .tmp/my-research-results/controls.json \
+  --out .tmp/my-research-results/verification.json
 ```
 
-安装会写入所选平台的适配器与配置，并保留可卸载的备份。重启或重新加载平台，使 Skill 和钩子生效；如采用独立状态目录，也要将该环境变量传给启动 Agent 的进程。不同平台的接入方法见下表，实际工具事件仍需通过一次端到端调用验证。
+默认执行全部 **23 个固定控制案例**。查看预期是否满足和 verifier 结果；攻击案例的 `blocked`、伪成功案例的 `incomplete` 都可能是正确结果。保留失败尝试，分享前按[证据导出规则](docs/research/data-export-policy.md)检查报告，不上传私密状态目录。
 
-| 平台 | Skill 目录 | 适配器与接入说明 |
+### 3. 可选：接入真实模型
+
+已有的实模型演示使用 **StepFun `step-3.7-flash` 远程规划**与 **DGX Spark 上的 Ornith 本地分析**。这条路径需要独立配置模型、私密凭据和硬件；与上面的无密钥路径分开运行、分开统计。
+
+从 [DGX 部署说明](deploy/dgx-spark/README.md)、[私密模型配置](docs/hackathon/step-plan.md)和[三轨复现指南](REPRODUCIBILITY.md)进入。机密分析的本地失败不能因此自动获准回退到远程模型。
+
+## 研究与证据
+
+以下数字属于已归档的特定运行，不能视作任意环境或未来版本的保证。
+
+| 已归档观察 | 结果 | 证据与范围 |
 | --- | --- | --- |
-| Hermes | `~/.hermes/skills/siq-agent-security` | [插件与安装包装](./adapters/runtime/hermes-agentshield/README.md)，平台名 `hermes` |
-| OpenClaw | `~/.openclaw/skills/siq-agent-security` 或其支持的共享 Skill 目录 | [安装策略与运行时插件](./adapters/runtime/openclaw-agentshield/README.md)，平台名 `openclaw` |
-| WorkBuddy / CodeBuddy | `~/.codebuddy/skills/siq-agent-security` | [CodeBuddy 工具钩子](./adapters/runtime/codebuddy-agentshield/README.md)，平台名 `codebuddy`；客户端需重启 |
-| Trae | `~/.trae/skills/siq-agent-security` | 当前仅审计，不能阻断运行中的工具 |
+| 固定控制案例 | **23/23** 满足预期 | [报告与验签摘要](docs/research/result-reproduction.md)；开发期间的受控夹具运行 |
+| 正常任务完成 | **5/5** | 同一控制报告中的全部正常任务 |
+| 不安全目标实际执行 | **0/13** | 注册了不安全目标的案例；分母与正常任务不同 |
+| 回执与效果封装校验 | **318** 条回执、**20** 个效果封装 | [独立验证输出](docs/research/evidence/reproduction-b/verification.json) |
+| 普通 Linux 浏览器复现 | **9/9** 场景通过 | [托管 Ubuntu 运行记录](docs/research/evidence/reproduction-a/hosted-linux-identity.json)；无需 GPU 或模型密钥 |
+| 首发源码 CI | **31** 项必需检查通过 | [发布源码记录](docs/research/evidence/release-ci.json)；对应 `aefab111` |
 
-随后可在 Agent 中请求：“盘点本机 Skill”“审查这个候选目录”“解释这条回执”。Skill 引导模型调用程序并呈现结果；权限批准由操作者完成。
+历史 StepFun 与 Ornith 正常任务 cohort 各保留了后续 **5/5** 的结果，早期 **4/5** 的失败也完整保留在[原始基准报告](docs/hackathon/benchmark-report.md)。这些小样本不构成统计保证，不能与固定夹具或后续演示合并分母。托管 CI 复现也不等于外部研究者的独立复现。
 
-**安装与版本校验：** 脚本先验证签名清单和 Skill 内容，再校验并暂存二进制。默认允许本地构建产物与 Release 哈希不同，并给出告警；设置 `SIQ_AGENT_SECURITY_REQUIRE_PINNED=1` 可要求匹配清单制品。此模式不适用于任意源码构建产物。
+研究入口：[研究问题](docs/research/research-questions.md) · [数据卡](docs/research/dataset-card.md) · [评价协议](docs/research/evaluation-protocol.md) · [逐项结论与证据](docs/research/claims-evidence.md)。当前没有已发表论文、DOI 或独立制品认证。
 
-当前 Shell / PowerShell 引导脚本已实现显式下载路径：找不到本地二进制且设置 `SIQ_AGENT_SECURITY_ALLOW_DOWNLOAD=1` 时，才从签名清单中的 URL 获取并验证制品。默认不下载；清单目前指向 v0.2.0，下载该版本不会获得当前 main 的 V2 增量。下载实现、发布兼容性与实机支持分别验收。
+## 组件与接入
 
-### 4. 审查一个候选 Skill
-
-在上述第二个终端中运行仓库的合成夹具：
-
-```bash
-"$SIQ_AGENT_SECURITY_BIN" admit \
-  "$SIQ_REPO_ROOT/skills/siq-agent-security/evals/fixtures/toxic-finreport-enhancer"
-# 预期：quarantine，退出码 3；这是测试中的预期阻断。
-
-"$SIQ_AGENT_SECURITY_BIN" admit \
-  "$SIQ_REPO_ROOT/skills/siq-agent-security/evals/fixtures/official-like"
-# 预期：admit_with_conditions；该目录是合成夹具，并非官方认证 Skill。
-```
-
-真实使用时，应在复制候选 Skill 到平台加载目录**之前**审查。WorkBuddy / CodeBuddy 当前没有通用安装前阻断入口；其运行时钩子不能替代这一步。
-
-在控制台刷新资产与准入结果，检查能力范围，起草 Grant，由操作者批准并部署。之后通过真实平台发起获准与越权调用，在回执页核对结果。
-
-服务运行时，Grant 变更使用控制台或管理 API。离线 CLI 需要先停止同一状态目录下的 `serve`，再由操作者执行；以下占位值应替换为实际输出：
-
-```bash
-"$SIQ_AGENT_SECURITY_BIN" grant '<admission_id>' --platform hermes --subject '<agent_id>'
-"$SIQ_AGENT_SECURITY_BIN" grant challenge '<grant_id>'
-"$SIQ_AGENT_SECURITY_BIN" grant approve '<grant_id>' \
-  --approve-as '<operator_id>' --challenge-id '<challenge_id>' --nonce '<nonce>'
-"$SIQ_AGENT_SECURITY_BIN" grant deploy '<grant_id>'
-```
-
-完成后重新启动服务。`--approve-as` 和挑战机制记录审批操作并防止对象混淆，不能单独证明操作者一定是真实人类。
-
-### 5. 核验、导出与卸载
-
-```bash
-"$SIQ_AGENT_SECURITY_BIN" verify
-"$SIQ_AGENT_SECURITY_BIN" export --out ./siq-agent-security-export.json
-"$SIQ_AGENT_SECURITY_BIN" incomplete
-```
-
-`verify` 检查回执哈希链和签名，发现断链时退出码为 `4`。脱敏导出不携带 token 或私钥，其派生签名证明导出投影自身的完整性，不冒充原始回执签名。
-
-`incomplete` 查看未完成的多文件提交。恢复操作为 `incomplete --recover`，必须在能够取得排他写锁时执行，通常需要先停止 `serve`。
-
-卸载所选平台适配器可运行 `"$SIQ_AGENT_SECURITY_BIN" adapter uninstall hermes`，再移除自己创建的 Skill 链接。保留状态目录以便继续核验历史记录。
-
-## 使用 Trusted Intent V2
-
-默认 `intent_enforcement=optional`：未绑定会话沿用 Grant 授权，新回执显式记录 `unbound`。需要每个会话都绑定 Intent 时，在停止服务后，将现有 `<state>/config.json` 中的对应设置合并为：
-
-```json
-{
-  "intent_enforcement": "required",
-  "enforcement_mode": "block"
-}
-```
-
-保留其他已有配置，再重新启动服务。**在当前开发分支中，无效的必需 Authority 在 `block`、`warn`、`audit_only` 下均硬拒绝。** `required` 缺绑定、撤销、来源无效等不能由 advisory 放宽；普通策略的建议模式保持兼容。`optional` 只允许从未绑定的旧会话沿用 Grant，已绑定会话不能通过删除或撤销绑定降级。
-
-V2 管理入口如下：
-
-| API | 用途 | 身份要求 |
+| 组件 | 职责 | 使用入口 |
 | --- | --- | --- |
-| `POST /v1/intents` | 校验并签发不可变 V2/V3 Intent | 配对产生的管理会话 |
-| `GET /v1/intents`、`GET /v1/intents/{id}` | 查询授权合同 | 管理会话 |
-| `POST /v1/intent-bindings` | 将 Intent 固定绑定到平台、Agent 和会话 | 管理会话 |
-| `GET /v1/intent-bindings`、`GET /v1/intent-bindings/{id}` | 查询绑定 | 管理会话 |
-| `POST /v1/intent-bindings/{id}/revoke` | 终态撤销一条绑定，保留历史记录 | 管理会话 |
-| `POST /v1/intents/{id}/revoke` | 全局撤销 Intent，影响全部关联会话及新绑定 | 管理会话 |
-| `POST /v1/decide`、`POST /v1/observe` | 提交动作与关联结果 | 适配器决策凭据 |
+| Secure Agent 与研究 Skills | 任务规划、动态选择研究 / 报告 / 交付能力 | [Agent 说明](apps/secure-agent/README.md)、[Skills](skills/) |
+| 本地 Go 运行时 | 准入、授权、管理 API、签名回执与效果核验 | [本地操作指南](AGENTSHIELD.md)、[开发规格](docs/agentshield-dev-spec-v1.md) |
+| 运行时适配器 | Hermes、OpenClaw、CodeBuddy 的具体工具入口接入 | [适配器目录](adapters/runtime/)、[能力矩阵](docs/agentshield-capability-matrix-v1.md) |
+| 企业控制面 | 多租户资产、证据、策略审批及 Edge 协调 | [控制面说明](docs/control-plane.md)、[生产运行手册](docs/enterprise-production-runbook-v1.md) |
+| Edge 与 Connectors | 配置、目录、框架、进程、容器及集群采集 | [Edge](edge/agent/)、[Connectors](connectors/)、[兼容说明](docs/compatibility.md) |
+| 合同与基准 | 跨组件数据合同、固定语料和证据验证 | [合同](packages/contracts/)、[Agent 基准](benchmarks/hackathon/README.md)、[运行时基准](benchmarks/runtime-security/README.md) |
 
-绑定请求示意：
+本地演示无需 PostgreSQL、企业登录或企业 API。平台的采集能力、工具阻断能力和实机验证状态分别登记；存在适配器不代表所有版本、所有调用路径均受保护。企业生产部署条件和未验证事项以对应运行手册为准。
 
-```json
-{
-  "platform": "hermes",
-  "session_id": "actual-session-id",
-  "agent_id": "actual-agent-id",
-  "intent_id": "issued-intent-id"
-}
-```
+## 安全边界
 
-先签发 Intent，再使用实际平台身份建立绑定。`intent_id` 来自签发响应，其他字段必须与适配器实际事件一致；签名和摘要由服务端生成。决策 token 不能调用以上管理接口，也不能通过把 Intent 填入工具参数完成授权。
+- **同 UID 不隔离**：当前桌面模式不能阻止同一操作系统用户的恶意进程读取密钥或改写状态；Python ToolGateway 不是 OS 沙箱。
+- **接入范围有限**：授权检查只覆盖正确接入的执行路径；来源注册与敏感级别分类仍依赖可信操作者。
+- **效果证明有范围**：文件与受控接收端的观察不代表对所有外部 SaaS 的交付证明；缺失或冲突的证据不能当作成功。
+- **实验结论有限**：固定小语料与模型夹具不代表通用提示注入防护、完整语义来源追踪或生产安全认证。跨平台编译也不等于各平台原生验收。
 
-完整字段见 [V2 Schema](./packages/contracts/intent-contract.v2.schema.json)、[合同样例](./apps/agentshield/testdata/contracts/intent-contract.v2.sample.json)和[工程报告](./docs/trusted-intent-v2-report-20260907-161622.md)。测试样例中的 ID、时间和签名用于合同验证，实际使用需按任务重新签发。当前没有专用 Intent CLI 子命令，也没有 Intent 解绑、覆盖或原会话换任务接口。
+完整说明见[威胁模型](docs/threat-model.md)、[能力矩阵](docs/agentshield-capability-matrix-v1.md)和[数据卡](docs/research/dataset-card.md)。未修复漏洞请通过 [SECURITY.md](SECURITY.md) 的私密入口报告。
 
-### 体验实验性 V3 与效果证据
+## 贡献与下一步
 
-新任务可按[V3 合同](./packages/contracts/intent-contract.v3.schema.json)签发参数来源约束，旧 V2 合同仍可读取。管理端注册可信 issuer；普通 decision 凭据只能上报 MCP/WEB/TOOL/AGENT/UNKNOWN 的低可信内容，不能签发 USER/IAM 权威。显式派生必须经过选择接口，不能把原结果的引用直接挪给已变化的参数。接口及样例见[Provenance API](./docs/provenance-api-v1.md)。
+欢迎普通 Linux 复现、同值来源解释、夹具诊断、指标纠错和有来源依据的负向案例。先阅读[贡献指南](CONTRIBUTING.md)，再选择[首批任务](docs/research/community-backlog.md)、[Issues](https://github.com/maoyadongsh/siq-agent-security/issues)或 [Discussions](https://github.com/maoyadongsh/siq-agent-security/discussions)。
 
-效果采样使用管理员签发、固定来源与范围的独立 observer 凭据，decision token 不能替代。文件 begin 保存原快照，finish 归档材料；跨重启由管理员显式接管，保持原期限并检查所有历史身份的撤销状态。`GET /v1/tasks/{task_id}/completion` 提供完成判定，工具返回 `success` 不会自动成为 verified。
+后续重点是长期归档与 DOI、外部独立复现、预先确定协议的新实验，以及论文与制品评审。新二进制研究版本仍需单独的分发与原生验收。实际进展见[开源实施记录](docs/research/operations-20260908.md)与[任务台账](docs/open-source-research-tasks-20260908.md)。贡献签署与评审遵循 [DCO](DCO) 和[治理规则](GOVERNANCE.md)，社区交流遵循[行为准则](CODE_OF_CONDUCT.md)。
 
-开发者可在隔离临时目录中复现组件流程：
+## 许可、引用与历史材料
 
-```bash
-python3 benchmarks/runtime-security/run.py --out /tmp/siq-runtime.json
-apps/control-api/.venv/bin/python benchmarks/runtime-security/evidence.py /tmp/siq-runtime.json
-python3 benchmarks/runtime-security/recovery_fixture.py --out /tmp/siq-recovery.json
-python3 benchmarks/runtime-security/performance.py --out /tmp/siq-performance.json
-```
+自有软件采用 **[Apache-2.0](LICENSE)**；明确列出的原创研究文档采用 **[CC BY 4.0](LICENSES/README.md)**。第三方代码、补丁与字体保留各自许可，详见[适用范围](LICENSES/scope.json)及[第三方归属](THIRD_PARTY_NOTICES.md)。模型权重和外部 API 服务不在项目许可之内。
 
-需要本地 Go 和已安装开发依赖的 Control API 虚拟环境。报告中的 D0–D5 分别注明实际证据与未评估值；无独立材料的样本不进入 D5 成功/失败分母。性能报告是暖态组件微基准，不是生产 SLA。完整复现说明见[基准文档](./benchmarks/runtime-security/README.md)。Hermes 已有配置化 MCP 结果上报和显式引用桥接，但原生 MCP 注册/调度器的完整集成仍待验收；未知工具继续保留 unknown 效果限制。
+引用软件请使用 **[CITATION.cff](CITATION.cff)**，并记录实际使用的版本、提交和语料摘要；[引用指南](docs/research/citation-guide.md)说明了源码与研究材料的区别。
 
-## 企业控制面启动
+[比赛演示入口](HACKATHON.md) · [V5 冻结快照](docs/hackathon/final-submission-state.md) · [研究技术报告](docs/research/technical-report.md) · [开发约定](AGENTS.md) · [持续集成](https://github.com/maoyadongsh/siq-agent-security/actions)
 
-企业形态在本地模式之外独立启动。以下仅用于隔离的开发环境，需要 Python 3.12+、uv、Node.js 22 和 npm。
-
-```bash
-# 终端 A：从仓库根目录进入 API 工程
-cd apps/control-api
-uv sync --dev --locked
-SIQ_AS_DEV=1 SIQ_AS_ALLOW_SQLITE=1 SIQ_AS_BOOTSTRAP_TENANT_ID=dev-tenant \
-  uv run uvicorn app.main:app --host 127.0.0.1 --port 8600
-```
-
-```bash
-# 终端 B：从仓库根目录进入前端工程
-cd apps/web
-npm ci
-VITE_DEV_MODE=true VITE_DEV_TENANT_ID=dev-tenant npm run dev -- --host 127.0.0.1
-```
-
-浏览器访问 Vite 输出的地址。需要处理后台任务时，在 API 工程另起 Worker，并使用同一组开发配置：
-
-```bash
-SIQ_AS_DEV=1 SIQ_AS_ALLOW_SQLITE=1 SIQ_AS_BOOTSTRAP_TENANT_ID=dev-tenant \
-  uv run python -m app.worker --once
-```
-
-`--once` 处理一轮任务；持续运行时去掉该参数。开发身份头仅用于此模式。生产需要 PostgreSQL、迁移、OIDC issuer / audience / JWKS、签名密钥注入及受控网络入口，不能把上述开发启动方式直接作为生产部署。
-
-PostgreSQL 开发 Compose、Edge 注册及执行后端配置见[企业控制面文档](./docs/control-plane.md)和[部署目录](./deploy/compose/)。本仓不直接导入其他 SIQ 仓库内部代码，也不查询其数据库；跨系统接入通过版本化 API 或事件合同完成。
-
-## 平台适配与 DGX Spark 验证
-
-### 平台能力按接入点和证据登记
-
-| 平台 / 后端 | 当前接入方式 | 已有证据与边界 |
-| --- | --- | --- |
-| Hermes | 安装包装、pre/post 工具插件 | 2026-09-05 Spark 本机插件 L0–L2 记录；最新 V2 全链路仍待实机验收 |
-| OpenClaw | 安装策略 `policy-exec`、运行时插件 | 隔离 HOME 下安装策略与调用合同记录；未因此宣称接管日常网关 |
-| WorkBuddy / CodeBuddy | PreToolUse / PostToolUse 钩子 | Linux 隔离 HOME 的真实 hook 记录；未完成 GUI 客户端完整 V2 验收 |
-| Trae | Skill 操作指引与审计 | 当前无法进行工具阻断 |
-| Claude Code / Codex | 矩阵中保留实验性 L0 条目 | 本轮没有运行时阻断支持声明 |
-| OpenShell | CLI 能力探测、网络策略操作与读回 | 本地适配器最高为 `readback_verified`；实际强制效果仍待验证 |
-
-L0 表示盘点 / 审计，L1 表示安装门禁，L2 表示运行时决策 / 回执，L3 表示 OpenShell 网络策略接入。某平台存在高档位设计，不代表该档位已实机验收；`readback_verified` 也不等于 `enforcement_verified`。
-
-正式声明以[签名 manifest](./skills/siq-agent-security/skill-manifest.json)、[能力矩阵](./docs/agentshield-capability-matrix-v1.md)与[兼容文档](./docs/compatibility.md)共同约束。交叉编译覆盖 Linux amd64 / arm64、macOS arm64 和 Windows amd64；编译结果不替代各系统上的运行与安全测试。
-
-### DGX Spark 的实际角色
-
-仓库归档了 2026-09-05 在 NVIDIA DGX Spark、NVIDIA GB10、Ubuntu 24.04、linux/arm64 环境下的安装、准入、授权、钩子与回执验证。v0.2.0 的 ARM 制品约 13.8 MB，大小是历史发布数据，当前源码构建以实际产物为准。
-
-Spark 可以承担业务模型的本地推理和 Agent 工作流，SIQ 在同机完成授权检查与审计。安全裁决核心运行于 CPU，不要求为规则判断加载 GPU 模型；其价值是使本地 AI 的工具访问具备可检查的权限边界。业务模型及其他工具是否出网，仍需按其配置与执行环境验证。
-
-本地服务绑定 loopback；OpenShell 集成先探测网关身份，不自动启动或接管现有网关。具体环境与限制见[实机证据索引](./docs/evidence/agentshield/README.md)。
-
-## 安全边界与当前限制
-
-安全能力的适用范围是产品接口的一部分。评估与部署时需保留以下事实：
-
-| 边界 | 当前状态 |
-| --- | --- |
-| 同一操作系统用户 | 默认 `desktop-same-uid`。协议分权、配对和审批挑战不能阻止同 UID 恶意进程读取密钥、改写状态或执行 CLI；`managed-linux` 尚未实现 |
-| 工具中介覆盖 | 只能治理已接入并正确执行决策的入口；无钩子、替代执行路径及平台绕过需要额外隔离与验证 |
-| 运行模式 | 无效必需 Authority 在三模式均硬拒绝；普通策略的 warn/audit_only 保留 advisory 语义。未验证 Authority 不等于获得权限 |
-| 工作目录授权 | caller `context.cwd` 不授予写权限；可信 ContextAssertion 校验签名、scope、期限及工作区约束。其证明范围仍取决于可信签发端，不等于 OS 路径隔离 |
-| 文件与网络资源 | 当前 V2 文件规范化采用 POSIX 路径语义；host 匹配不证明最终 DNS / 重定向目的地；路径匹配不提供 OS 对象隔离 |
-| 结果真实性 | Observation 证明结果与前置动作的协议关联；签名链不自动证明工具自报成功为真实业务效果 |
-| 来源与委派 | 已实现选定高影响参数的显式签名来源绑定、受限 MCP 上报与确定性选择；不提供完整语义因果追踪、Delegation DAG 或通用行为沙箱 |
-| 生命周期与性能 | Grant、Intent binding 与全局 Intent 均有撤销路径；效果恢复不恢复执行授权。已有分阶段与完整 Engine.Decide 采样，长期生产负载仍需验证 |
-
-现有签名链提供完整性检查及恢复依据；同 UID 威胁模型下不能宣称密钥不可访问或历史记录绝对不可伪造。检测规则也不能完整识别所有自然语言提示注入。
-
-具体威胁、测试映射和整改任务见[威胁模型](./docs/threat-model.md)及[下一阶段开发计划](./docs/provenance-bound-effect-development-plan-20260907-180117.md)。
-
-## 开发与验证
-
-### 可追溯验证记录
-
-截至本 README 基线，已有以下工程证据。表中的历史结果不表示每次阅读 README 时都重新执行过测试。
-
-| 范围 | 已归档结果 | 证据 |
-| --- | --- | --- |
-| 当前 main CI | `d127711`：ci / runtime-security 均成功 | [提交状态与运行 ID](docs/hackathon/final-submission-state.md) |
-| 本地 V2 回归 | Go 测试 / race / vet、32 并发、进程强杀恢复、历史签名兼容；Python 501 项、Web 11 项及构建通过 | [2026-09-07 进度报告](./docs/trusted-intent-v2-progress-20260907-164919.md) |
-| 跨语言合同 | 固定签名向量与 Schema 验证；31 组共享匹配语料，其中授权匹配结论由 Go 测试执行 | [合同测试](./apps/control-api/app/tests/test_intent_v2_contracts.py) |
-| 平台实机 | 2026-09-05 Spark 上的插件 / 隔离钩子记录 | [平台证据目录](./docs/evidence/agentshield/README.md) |
-
-绑定查找微基准在 Go 1.26.5 / linux/arm64、4,096 个合成绑定、200 个样本下，P50 为 0.2194 ms、P95 为 0.2396 ms、P99 为 0.3003 ms。该测量包含目标绑定与 Intent 的读取 / 验签，**不包含 HTTP、回执 fsync、模型推理与工具执行，不是端到端 SLA**。[原始数据](./docs/evidence/intent-v2/local-20260907-164553-direct-bindings-4096.json)
-
-当前 Skill eval 集合有 7 个条目，另有工程测试。项目尚未公布完整研究基准上的攻击成功率、正常任务完成率或独立安全认证结果。
-
-### 常用验证命令
-
-```bash
-# 本地 Go 模块；从仓库根目录运行
-go -C apps/agentshield vet ./...
-go -C apps/agentshield test ./...
-go -C apps/agentshield test -race ./...
-
-# 企业 API 与跨语言合同
-(cd apps/control-api && uv sync --dev --locked && uv run ruff check app && uv run pytest)
-
-# 两种前端构建
-npm --prefix apps/web test
-npm --prefix apps/web run build:local
-npm --prefix apps/web run build
-
-# 适配器与能力声明门禁
-node scripts/test-openclaw-adapter.cjs
-python3 scripts/check_capability_honesty.py
-git diff --check
-```
-
-运行前先完成各组件依赖安装。Edge 和每个 Connector 是独立 Go module，需分别在相应目录执行检查；完整模块清单和静态检查入口以 [CI 工作流](./.github/workflows/ci.yml) 为准。
-
-复测绑定查找性能：
-
-```bash
-go -C apps/agentshield run ./cmd/perfbaseline \
-  -intent -intent-bindings 4096 -intent-samples 200 -out /tmp/siq-intent-perf.json
-```
-
-修改本地前端后，运行 `npm --prefix apps/web run build:local`，再重新构建 Go 程序。开发热更新可用 `npm --prefix apps/web run dev:local`，其 API 代理指向已启动的 `127.0.0.1:47611`。
-
-### 常见问题
-
-| 现象 | 检查与处理 |
-| --- | --- |
-| 页面是占位内容或未反映新界面 | 先构建 `build:local`，再构建并重启实际运行的 Go 二进制 |
-| 配对失败或刷新后无管理权限 | 检查服务实例和端口；配对码单次有效，必要时重启服务重新配对 |
-| `binary not found` | 设置 `SIQ_AGENT_SECURITY_BIN`；下载发布版本需显式开启，并检查版本差异 |
-| 清单校验失败 | 检查 Python / OpenSSL、Skill 内容和制品版本；不要把完整性失败当成可忽略的普通告警 |
-| Grant CLI 提示 writer lock | 服务运行期间通过控制台管理；需要离线 CLI 时先停止同一状态目录的服务 |
-| 所有工具调用被拒绝 | 检查模式、已部署 Grant 的主体、平台身份，以及 required 模式下的 Intent 绑定 |
-| 安装 Skill 后没有运行时回执 | 检查平台是否支持钩子、适配器状态、平台重载、状态目录与实际工具事件 |
-
-## 后续路线（比赛后，future）
-
-| 阶段 | 重点任务 | 交付目标 |
-| --- | --- | --- |
-| 授权与交付收口 | 可信 cwd、授权硬门禁合同、适配器失联语义、真实 V2 验收、安装文档与候选发布 | 一个平台上的完整可复现安全工作流 |
-| 来源约束与效果证据 | 受信上下文声明、受控参数来源、独立文件 / 网络效果证据、受管 Linux 边界 | 在明确威胁模型下验证来源与实际操作 |
-| 企业与生态扩展 | Intent 分发与撤销、受控 MCP 中介、更多实机平台、持续对抗评测 | 可运营的多环境治理能力 |
-| 研究性能力 | 有界来源图、行为沙箱编排、跨 Agent 委派 | 根据效用、风险与复杂度逐步验证 |
-
-详尽任务、依赖和验收条件见[前沿优化开发计划](./docs/provenance-bound-effect-development-plan-20260907-180117.md)。参赛演示和企业 PoC 可以选择明确场景先交付；长期路线中的新增能力不计入当前支持范围。
-
-## 仓库地图与文档
-
-```text
-skills/siq-agent-security/     Skill、安装脚本、签名 manifest、评测夹具
-apps/agentshield/              本地 Go 核心、CLI、管理 API、内嵌前端
-apps/web/                      本地与企业两种前端入口
-apps/control-api/              企业 API、Worker、数据库迁移与 Python 测试
-adapters/runtime/              Hermes / OpenClaw / CodeBuddy 运行时适配器
-edge/agent/                    Edge 注册、任务、签名证据与 Connector 协议
-connectors/                    框架、目录、进程、容器及集群采集
-packages/contracts/            JSON Schema、协议与兼容合同
-scripts/                       静态门禁、回归、发布与性能辅助
-deploy/compose/                企业开发环境部署
-docs/                          规格、ADR、威胁模型、计划与验证证据
-site/                          项目展示站
-```
-
-对外名称、CLI 和 Skill 名称统一为 `siq-agent-security`；部分源码目录仍保留 `agentshield` 作为历史内部路径。
-
-| 阅读目的 | 入口 |
-| --- | --- |
-| 本地操作与演示 | [AGENTSHIELD.md](./AGENTSHIELD.md) |
-| 本地架构决策 | [ADR-011：便携 Skill 形态](./docs/adr/0011-portable-skill-form.md) |
-| 本地开发规格 | [开发规格](./docs/agentshield-dev-spec-v1.md) |
-| V2 授权与动作恢复 | [基础报告](./docs/trusted-intent-v2-report-20260907-161622.md)、[后续进度](./docs/trusted-intent-v2-progress-20260907-164919.md) |
-| 企业控制面 | [控制面文档](./docs/control-plane.md)、[生产运行手册](./docs/enterprise-production-runbook-v1.md) |
-| 支持范围与威胁 | [能力矩阵](./docs/agentshield-capability-matrix-v1.md)、[威胁模型](./docs/threat-model.md) |
-| 检测规则与测试 | [检测基线](./docs/detection-baseline.md)、[合同目录](./packages/contracts/README.md) |
-| 发布与制品 | [发布检查](./docs/agentshield-release-checklist-v1.md)、[签名 manifest](./skills/siq-agent-security/skill-manifest.json) |
-| 开发约定 | [仓库指南](./AGENTS.md) |
-
-参与开发时，先确定合同、能力边界和验证方法。新增适配器需要实际接入证据，安全修复需要正负向测试；涉及身份、授权或签名语义的变更，应同步更新版本化合同、实现、测试和使用说明。
-
-
-2026-09-08工具链安全验证：本地Go 1.26.5的govulncheck发现5项可达标准库漏洞，使用`GOTOOLCHAIN=go1.26.6`复扫未发现漏洞。旧版本兼容测试不代表其标准库安全；构建发布二进制应使用已修复工具链，例如在本地Go模块执行`GOTOOLCHAIN=go1.26.6 go build ./cmd/agentshield`。独立CI任务runtime-security-toolchain严格运行漏洞扫描及race/vet；结果只适用于对应源码、工具链和当时漏洞库。详见[工具链核验](docs/provenance-bound-effect-v1-toolchain-20260908.md)。
+比赛快照保留当时的源码、制品、视频和实验分母；本轮研究发布及后续文档更新使用各自的身份记录。


### PR DESCRIPTION
Make the repository homepage Chinese by default and add a matching English README with reciprocal language links. Both versions follow the same structure: project purpose, four observable scenarios, model-key-free quick start, fixed benchmark reproduction, scoped evidence, component entry points, security boundaries, contribution and licensing.

Replace the long mixture of historical product claims and competition state with the actual unsigned source prerelease and archived research evidence. Preserve links to the frozen V5 material and detailed operations/specifications; correct the local operations guide's obsolete reference to installation steps in the root README. Runtime, release artifacts and benchmark data are unchanged.

Validation: both READMEs have matching commands, metric tokens and section counts; local links/anchors and Bash syntax pass; both Mermaid diagrams render with the pinned local renderer; research metadata, task ledger and git diff --check pass. Documentation-only change, no live-model calls or runtime retest added locally. Existing required CI remains in force. The previously disclosed sole-maintainer owner-authorized integration exception applies only after all 31 checks pass.
