### PR TITLE
docs: introduce blue SIQ shield identity for README

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="site/favicon.svg" width="64" height="64" alt="SIQ" />
+  <img src="site/siq-shield.svg" width="96" height="96" alt="SIQ blue shield logo" />
 </p>
 
 <h1 align="center">SIQ Agent Security</h1>

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="site/favicon.svg" width="64" height="64" alt="SIQ" />
+  <img src="site/siq-shield.svg" width="96" height="96" alt="SIQ 蓝色盾牌标识" />
 </p>
 
 <h1 align="center">SIQ Agent Security</h1>

--- a/site/siq-shield.svg
+++ b/site/siq-shield.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" fill="none" role="img" aria-labelledby="title desc">
+  <title id="title">SIQ Agent Security</title>
+  <desc id="desc">A blue shield with white SIQ lettering, representing the secure runtime for Agent Skills.</desc>
+  <defs>
+    <linearGradient id="shield" x1="29" y1="18" x2="101" y2="108" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#2563EB"/>
+      <stop offset="1" stop-color="#12346B"/>
+    </linearGradient>
+  </defs>
+  <path d="M64 8C79 18 93 22 108 25V61C108 87 91 105 64 120C37 105 20 87 20 61V25C35 22 49 18 64 8Z" fill="url(#shield)" stroke="#60A5FA" stroke-width="2" stroke-linejoin="round"/>
+  <path d="M64 19C76 27 89 31 98 33V61C98 81 85 97 64 109C43 97 30 81 30 61V33C39 31 52 27 64 19Z" stroke="#BFDBFE" stroke-opacity=".4" stroke-width="1.5"/>
+  <g stroke="#FFFFFF" stroke-width="5.5" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M48 51H39C30 51 30 64 39 64H42C51 64 51 77 42 77H33"/>
+    <path d="M58 51H68M63 51V77M58 77H68"/>
+    <path d="M87 51C80 51 77 56 77 64S80 77 87 77S97 72 97 64S94 51 87 51Z"/>
+    <path d="M89 70L99 80"/>
+  </g>
+</svg>


### PR DESCRIPTION
Replace the document-shaped README icon with a blue SIQ shield that expresses the project's Secure Runtime for Agent Skills identity. Both language homepages use the new mark at 96px.

The mark is a self-contained SVG with a restrained blue gradient, a double shield outline, and original white SIQ path lettering. It includes an accessible title/description and has no font, script, image or network dependencies. The existing site favicon is retained as a separate asset.

Validation: parsed SVG structure and checked for external/active content; rendered and visually inspected 32/64/96/128px versions on light and dark backgrounds. Both README bodies and Mermaid diagrams are byte-for-byte unchanged below the icon. `git diff --check` passed.

Scope: one new SVG and two README image references. Merge follows the existing owner-authorized sole-maintainer exception in GOVERNANCE.md only after all 31 required checks pass on the submitted head; it is not independent review.
