### PR TITLE
docs: refine geometric SIQ shield lettering

### DIFF
--- a/site/siq-shield.svg
+++ b/site/siq-shield.svg
@@ -9,10 +9,10 @@
   </defs>
   <path d="M64 8C79 18 93 22 108 25V61C108 87 91 105 64 120C37 105 20 87 20 61V25C35 22 49 18 64 8Z" fill="url(#shield)" stroke="#60A5FA" stroke-width="2" stroke-linejoin="round"/>
   <path d="M64 19C76 27 89 31 98 33V61C98 81 85 97 64 109C43 97 30 81 30 61V33C39 31 52 27 64 19Z" stroke="#BFDBFE" stroke-opacity=".4" stroke-width="1.5"/>
-  <g stroke="#FFFFFF" stroke-width="5.5" stroke-linecap="round" stroke-linejoin="round">
-    <path d="M48 51H39C30 51 30 64 39 64H42C51 64 51 77 42 77H33"/>
-    <path d="M58 51H68M63 51V77M58 77H68"/>
-    <path d="M87 51C80 51 77 56 77 64S80 77 87 77S97 72 97 64S94 51 87 51Z"/>
-    <path d="M89 70L99 80"/>
+  <g fill="#FFFFFF" transform="translate(33 49) scale(.88 1)">
+    <path d="M22 0H5L0 5V13L5 18H15V21H0V28H17L22 23V15L17 10H7V7H22Z"/>
+    <path d="M29 0H36V28H29Z"/>
+    <path fill-rule="evenodd" d="M48 0H62L67 5V23L62 28H48L43 23V5ZM51 7L50 8V20L51 21H59L60 20V8L59 7Z"/>
+    <path d="M55 17H62L71 30H63Z"/>
   </g>
 </svg>


### PR DESCRIPTION
Refine the SIQ shield lettering to match the user's request for a stronger, more coordinated security identity. Replace rounded monoline letters with compact, bold geometric path lettering, chamfered corners, a plain vertical I and a shorter Q tail. The narrower wordmark increases clearance inside the shield.

Only the lettering group in site/siq-shield.svg changes. Shield geometry, blue palette, accessibility metadata, README layout and all diagrams remain unchanged. Lettering is original vector geometry and requires no font files or external resources.

Validation: XML comparison confirms every non-lettering SVG element is unchanged; visually inspected before/after and 32/64/96/128px rendering on light/dark backgrounds; git diff --check passed.

Merge follows the existing owner-authorized sole-maintainer exception in GOVERNANCE.md only after all 31 required checks pass on the submitted head. It is not independent review.
