### PR TITLE
docs: match SIQ title typography and increase shield clearance

### DIFF
--- a/site/siq-shield.svg
+++ b/site/siq-shield.svg
@@ -9,10 +9,5 @@
   </defs>
   <path d="M64 8C79 18 93 22 108 25V61C108 87 91 105 64 120C37 105 20 87 20 61V25C35 22 49 18 64 8Z" fill="url(#shield)" stroke="#60A5FA" stroke-width="2" stroke-linejoin="round"/>
   <path d="M64 19C76 27 89 31 98 33V61C98 81 85 97 64 109C43 97 30 81 30 61V33C39 31 52 27 64 19Z" stroke="#BFDBFE" stroke-opacity=".4" stroke-width="1.5"/>
-  <g fill="#FFFFFF" transform="translate(33 49) scale(.88 1)">
-    <path d="M22 0H5L0 5V13L5 18H15V21H0V28H17L22 23V15L17 10H7V7H22Z"/>
-    <path d="M29 0H36V28H29Z"/>
-    <path fill-rule="evenodd" d="M48 0H62L67 5V23L62 28H48L43 23V5ZM51 7L50 8V20L51 21H59L60 20V8L59 7Z"/>
-    <path d="M55 17H62L71 30H63Z"/>
-  </g>
+  <text x="64" y="69" fill="#FFFFFF" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif" font-size="25" font-weight="600" text-anchor="middle">SIQ</text>
 </svg>


### PR DESCRIPTION
Use README-style sans-serif SIQ lettering inside the shield, replacing the custom geometric paths. The user requested the title's font style, clear space within the inner outline, two units smaller text and lighter boldness. The final SVG uses a system/Segoe UI/Helvetica/Arial font stack at size 25 and weight 600, centered at x=64 with baseline y=69.

Only the lettering element changes. Shield geometry, colors, accessibility metadata, README layout and all diagrams are preserved. The SVG uses installed system fonts and does not load external font files; the exact face follows the reader's available fonts.

Validation: parsed SVG and compared all non-lettering elements; browser geometry checks verified the entire text bounding box plus four SVG units of clear space remains inside the inner shield for five local font-stack/fallback settings, including the Q tail. Visually inspected title comparison and 64/96/128px light/dark previews. git diff --check passed.

Merge follows the existing owner-authorized sole-maintainer exception in GOVERNANCE.md only after all 31 required checks pass on the submitted head. It is not independent review.
