### PR TITLE
docs: increase SIQ shield lettering by one size

### DIFF
--- a/site/siq-shield.svg
+++ b/site/siq-shield.svg
@@ -9,5 +9,5 @@
   </defs>
   <path d="M64 8C79 18 93 22 108 25V61C108 87 91 105 64 120C37 105 20 87 20 61V25C35 22 49 18 64 8Z" fill="url(#shield)" stroke="#60A5FA" stroke-width="2" stroke-linejoin="round"/>
   <path d="M64 19C76 27 89 31 98 33V61C98 81 85 97 64 109C43 97 30 81 30 61V33C39 31 52 27 64 19Z" stroke="#BFDBFE" stroke-opacity=".4" stroke-width="1.5"/>
-  <text x="64" y="69" fill="#FFFFFF" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif" font-size="25" font-weight="600" text-anchor="middle">SIQ</text>
+  <text x="64" y="69" fill="#FFFFFF" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif" font-size="26" font-weight="600" text-anchor="middle">SIQ</text>
 </svg>


### PR DESCRIPTION
Increase only the SIQ lettering font-size from 25 to 26, as requested. Font family, weight 600, position, color, shield geometry and README references are unchanged.

Validation: exact text comparison confirms this is the sole change; browser geometry checks confirm the text bounds plus four SVG units of clearance remain inside the inner shield across five local font-stack/fallback settings; light/dark previews rendered; git diff --check passed.

Merge follows the existing owner-authorized sole-maintainer exception in GOVERNANCE.md after all 31 required checks pass on the submitted head. It is not independent review.
