### PR TITLE
release: authenticate research assets with Sigstore

### DIFF
--- a/.github/workflows/release-signing.yml
+++ b/.github/workflows/release-signing.yml
@@ -1,0 +1,98 @@
+name: release-signing
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Reviewed research release to sign
+        required: true
+        default: research-v0.1.0-rc.1
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-signing
+  cancel-in-progress: false
+
+jobs:
+  sign-release:
+    if: github.repository == 'maoyadongsh/siq-agent-security' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: write
+      id-token: write
+    env:
+      GH_TOKEN: ${{ github.token }}
+      GH_REPO: maoyadongsh/siq-agent-security
+      RELEASE_TAG: ${{ inputs.tag }}
+      SIGNER: https://github.com/maoyadongsh/siq-agent-security/.github/workflows/release-signing.yml@refs/heads/main
+      ISSUER: https://token.actions.githubusercontent.com
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+        with:
+          persist-credentials: false
+      - name: Validate reviewed release identity before network access
+        run: |
+          python3 - <<'PY'
+          import json, os
+          record = json.load(open('docs/research/evidence/github-research-release.json'))
+          if os.environ['RELEASE_TAG'] != record['tag']:
+              raise SystemExit('Release must have a reviewed publication record before signing')
+          PY
+      - name: Download and validate original release bytes
+        run: |
+          mkdir -p "$RUNNER_TEMP/siq-release"
+          gh release download "$RELEASE_TAG" --dir "$RUNNER_TEMP/siq-release" \
+            --pattern SHA256SUMS --pattern SOURCE-INFO.json \
+            --pattern "siq-agent-security-$RELEASE_TAG.tar.gz"
+          git fetch --no-tags origin "refs/tags/$RELEASE_TAG"
+          SOURCE_SHA=$(git rev-parse 'FETCH_HEAD^{commit}')
+          python3 scripts/research/verify_release_assets.py \
+            --directory "$RUNNER_TEMP/siq-release" \
+            --record docs/research/evidence/github-research-release.json \
+            --tag "$RELEASE_TAG" --source-sha "$SOURCE_SHA"
+          echo "SOURCE_SHA=$SOURCE_SHA" >> "$GITHUB_ENV"
+      - uses: sigstore/cosign-installer@ba7bc0a3fef59531c69a25acd34668d6d3fe6f22 # v4.1.0
+        with:
+          cosign-release: v3.1.3
+      - name: Sign checksum manifest with GitHub OIDC identity
+        working-directory: ${{ runner.temp }}/siq-release
+        run: cosign sign-blob --yes --bundle SHA256SUMS.sigstore.json SHA256SUMS
+      - name: Verify signature and reject tampering and wrong identity
+        working-directory: ${{ runner.temp }}/siq-release
+        run: |
+          cosign verify-blob --bundle SHA256SUMS.sigstore.json \
+            --certificate-identity "$SIGNER" --certificate-oidc-issuer "$ISSUER" SHA256SUMS
+          cp SHA256SUMS tampered
+          echo tampered >> tampered
+          if cosign verify-blob --bundle SHA256SUMS.sigstore.json \
+            --certificate-identity "$SIGNER" --certificate-oidc-issuer "$ISSUER" tampered; then
+            echo '::error::Tampered content passed verification'
+            exit 1
+          fi
+          if cosign verify-blob --bundle SHA256SUMS.sigstore.json \
+            --certificate-identity "$SIGNER-untrusted" --certificate-oidc-issuer "$ISSUER" SHA256SUMS; then
+            echo '::error::Wrong signer passed verification'
+            exit 1
+          fi
+          sha256sum --check --strict SHA256SUMS
+      - name: Attach signature without overwriting existing release assets
+        run: gh release upload "$RELEASE_TAG" "$RUNNER_TEMP/siq-release/SHA256SUMS.sigstore.json"
+      - name: Independently download and verify published assets
+        run: |
+          mkdir -p "$RUNNER_TEMP/siq-release-readback"
+          gh release download "$RELEASE_TAG" --dir "$RUNNER_TEMP/siq-release-readback" \
+            --pattern SHA256SUMS --pattern SOURCE-INFO.json --pattern SHA256SUMS.sigstore.json \
+            --pattern "siq-agent-security-$RELEASE_TAG.tar.gz"
+          python3 scripts/research/verify_release_assets.py \
+            --directory "$RUNNER_TEMP/siq-release-readback" \
+            --record docs/research/evidence/github-research-release.json \
+            --tag "$RELEASE_TAG" --source-sha "$SOURCE_SHA"
+          cd "$RUNNER_TEMP/siq-release-readback"
+          cosign verify-blob --bundle SHA256SUMS.sigstore.json \
+            --certificate-identity "$SIGNER" --certificate-oidc-issuer "$ISSUER" SHA256SUMS
+          sha256sum --check --strict SHA256SUMS
+          echo "Signed and freshly verified $RELEASE_TAG at source $SOURCE_SHA" >> "$GITHUB_STEP_SUMMARY"

--- a/docs/research/release-authentication.md
+++ b/docs/research/release-authentication.md
@@ -1,7 +1,41 @@
 # Release authentication
 
-No real publisher seed is configured in the supported task/release environment variables checked during this cycle. The candidate therefore states `official_signature=false`. No test, historical-development or newly generated temporary key is substituted for publisher authentication.
+The original 2026-09-08 source publication was unsigned. No real publisher seed was configured, so its immutable `SOURCE-INFO.json` records `official_signature=false`. Historical evidence describes that original event, not subsequent detached signatures.
 
-SHA256SUMS verifies downloaded byte integrity. GitHub's release page and immutable source commit identify the repository location and version; they are not a claim of the project's historical Skill publisher signature. The existing signed v0.2.0 Skill manifest authenticates its own stated subject only. No GitHub artifact attestation was generated in this cycle and no claim of one is made.
+## Repository-identity release signing
+
+The owner authorized digital signing on 2026-09-09. The [release-signing workflow](../../.github/workflows/release-signing.yml) uses Cosign v3.1.3 and GitHub Actions OIDC to sign the existing `SHA256SUMS` with a short-lived Sigstore certificate. No long-lived publisher private key or repository signing secret is required. The certificate binds the signature to this repository's workflow on `main`; Sigstore records public signing evidence in its transparency log.
+
+Status: workflow prepared; do not describe the release as signed until the bundle has been published and freshly verified.
+
+The detached `SHA256SUMS.sigstore.json` bundle contains the signature, certificate and transparency evidence. The signed checksum manifest authenticates both the named source archive and `SOURCE-INFO.json`. It does not cover GitHub's automatically generated ZIP/tar downloads, other tags, or arbitrary added assets. This is a post-publication signature over existing bytes, not a claim that the signing job originally built the archive. No GitHub artifact build-provenance attestation is claimed.
+
+The original tag, archive, metadata and checksum bytes remain unchanged. In particular, the old `official_signature=false` field remains an accurate record of packaging time and of the absence of the historical Skill publisher-key signature. Current detached signing status is recorded separately. The existing v0.2.0 Skill signature covers only its own stated subject.
+
+## Verify a downloaded release
+
+Install [Cosign](https://docs.sigstore.dev/cosign/system_config/installation/) (the workflow is tested with v3.1.3) and GitHub CLI. Download into a new directory:
+
+```bash
+mkdir siq-release-verify
+cd siq-release-verify
+gh release download research-v0.1.0-rc.1 --repo maoyadongsh/siq-agent-security \
+  --pattern SHA256SUMS --pattern SHA256SUMS.sigstore.json \
+  --pattern SOURCE-INFO.json --pattern siq-agent-security-research-v0.1.0-rc.1.tar.gz
+cosign verify-blob --bundle SHA256SUMS.sigstore.json \
+  --certificate-identity 'https://github.com/maoyadongsh/siq-agent-security/.github/workflows/release-signing.yml@refs/heads/main' \
+  --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
+  SHA256SUMS
+# Proceed only after signature verification succeeds.
+sha256sum --check --strict SHA256SUMS
+```
+
+Require both commands to succeed. Pin the exact certificate identity and issuer above; never replace them with a permissive wildcard or disable transparency-log verification. A checksum alone authenticates no publisher. A valid signature establishes repository workflow identity, not legal ownership, code safety or scientific validity.
+
+## Maintainer operation
+
+Run `gh workflow run release-signing.yml --ref main -f tag=research-v0.1.0-rc.1` after this workflow is integrated. Only the canonical repository on `main` can run the signing job. It verifies the tag's resolved source commit and all original asset sizes and hashes against the reviewed [publication record](evidence/github-research-release.json) before signing. It rejects substituted archives/metadata, modified checksum lists, unknown tags and moved tags. The signing job executes no code from the downloaded archive.
+
+The workflow verifies the signature, tests rejection of tampered bytes and a wrong signer, uploads only the new signature bundle without `--clobber`, then downloads and verifies the published files again. If a rerun reports an existing bundle, inspect and verify that bundle; do not delete or overwrite it to hide the previous signing event. Additional releases require their own reviewed publication record and an explicit update of the workflow's record selection. This prevents signing arbitrary unreviewed release assets.
 
 Receipt-chain verification proves internal experiment consistency under the recorded keys, separately from release provenance and separately from whether an experiment supports a scientific conclusion. A signed release would not enlarge same-UID isolation, observer scope or statistical claims.

--- a/scripts/research/test_verify_release_assets.py
+++ b/scripts/research/test_verify_release_assets.py
@@ -1,0 +1,74 @@
+import hashlib
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from verify_release_assets import verify
+
+
+class ReleaseAssetsTest(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.directory = Path(self.temp.name)
+        self.tag = "research-v0.1.0-rc.1"
+        self.source = "a" * 40
+        self.archive = f"siq-agent-security-{self.tag}.tar.gz"
+        (self.directory / self.archive).write_bytes(b"source fixture")
+        archive_hash = hashlib.sha256(b"source fixture").hexdigest()
+        (self.directory / "SOURCE-INFO.json").write_text(json.dumps({
+            "version": self.tag, "source_sha": self.source,
+            "archive": self.archive, "archive_sha256": archive_hash,
+        }))
+        items = [{"name": name, "sha256": hashlib.sha256((self.directory / name).read_bytes()).hexdigest(),
+                  "bytes": (self.directory / name).stat().st_size}
+                 for name in [self.archive, "SOURCE-INFO.json"]]
+        self.record = {"tag": self.tag, "tag_source_sha": self.source, "fresh_download_verified": items}
+        (self.directory / "SHA256SUMS").write_text("".join(f'{i["sha256"]}  {i["name"]}\n' for i in items))
+
+    def check(self):
+        return verify(self.directory, self.record, self.tag, self.source)
+
+    def test_original_assets_pass(self):
+        self.assertEqual(self.check()["source_sha"], self.source)
+
+    def test_replaced_archive_and_checksum_are_rejected(self):
+        (self.directory / self.archive).write_bytes(b"attacker bytes")
+        checksum = self.directory / "SHA256SUMS"
+        checksum.write_text(checksum.read_text().replace(
+            self.record["fresh_download_verified"][0]["sha256"], hashlib.sha256(b"attacker bytes").hexdigest()))
+        with self.assertRaisesRegex(ValueError, "asset differs"):
+            self.check()
+
+    def test_modified_metadata_is_rejected(self):
+        (self.directory / "SOURCE-INFO.json").write_text("{}")
+        with self.assertRaisesRegex(ValueError, "asset differs"):
+            self.check()
+
+    def test_extra_checksum_path_is_rejected(self):
+        with (self.directory / "SHA256SUMS").open("a") as stream:
+            stream.write("0" * 64 + "  ../../other\n")
+        with self.assertRaisesRegex(ValueError, "checksum manifest"):
+            self.check()
+
+    def test_moved_tag_is_rejected(self):
+        self.source = "b" * 40
+        with self.assertRaisesRegex(ValueError, "tag/source"):
+            self.check()
+
+    def test_unreviewed_tag_is_rejected(self):
+        self.tag = "research-v0.1.0-rc.2"
+        with self.assertRaisesRegex(ValueError, "tag/source"):
+            self.check()
+
+    def test_symlink_is_rejected(self):
+        target = self.directory / self.archive
+        target.rename(self.directory / "elsewhere")
+        target.symlink_to("elsewhere")
+        with self.assertRaisesRegex(ValueError, "nonregular"):
+            self.check()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/research/verify_release_assets.py
+++ b/scripts/research/verify_release_assets.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Reject release bytes that differ from the reviewed publication record."""
+
+import argparse
+import hashlib
+import json
+import re
+from pathlib import Path
+
+
+def digest(path):
+    with path.open("rb") as stream:
+        return hashlib.file_digest(stream, "sha256").hexdigest()
+
+
+def verify(directory, record, tag, source_sha):
+    if not re.fullmatch(r"research-v[0-9]+\.[0-9]+\.[0-9]+-rc\.[1-9][0-9]*", tag):
+        raise ValueError("invalid research release tag")
+    if record["tag"] != tag or record["tag_source_sha"] != source_sha:
+        raise ValueError("release tag/source differs from reviewed record")
+    if not re.fullmatch(r"[0-9a-f]{40}", source_sha):
+        raise ValueError("invalid source commit")
+    archive = f"siq-agent-security-{tag}.tar.gz"
+    expected = {item["name"]: item for item in record["fresh_download_verified"]}
+    if set(expected) != {archive, "SOURCE-INFO.json"} or len(record["fresh_download_verified"]) != 2:
+        raise ValueError("record must cover exactly the source archive and metadata")
+    for name in [archive, "SOURCE-INFO.json", "SHA256SUMS"]:
+        path = directory / name
+        if path.is_symlink() or not path.is_file():
+            raise ValueError("missing or nonregular release asset: " + name)
+        if name in expected:
+            item = expected[name]
+            if path.stat().st_size != item["bytes"] or digest(path) != item["sha256"]:
+                raise ValueError("asset differs from reviewed publication: " + name)
+    checksums = "".join(f'{expected[name]["sha256"]}  {name}\n' for name in [archive, "SOURCE-INFO.json"])
+    if (directory / "SHA256SUMS").read_bytes() != checksums.encode():
+        raise ValueError("checksum manifest differs from reviewed publication")
+    info = json.loads((directory / "SOURCE-INFO.json").read_text())
+    if (info["version"] != tag or info["source_sha"] != source_sha
+            or info["archive"] != archive or info["archive_sha256"] != expected[archive]["sha256"]):
+        raise ValueError("source metadata identity mismatch")
+    return {"tag": tag, "source_sha": source_sha, "sha256sums_sha256": digest(directory / "SHA256SUMS")}
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--directory", type=Path, required=True)
+    parser.add_argument("--record", type=Path, required=True)
+    parser.add_argument("--tag", required=True)
+    parser.add_argument("--source-sha", required=True)
+    args = parser.parse_args()
+    print(json.dumps(verify(args.directory, json.loads(args.record.read_text()), args.tag, args.source_sha)))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
The research prerelease currently publishes checksums without a verifiable release signature. Add a manually triggered, main-only Sigstore/Cosign workflow that authenticates the original checksum manifest using this repository’s GitHub OIDC identity, covering the existing source archive and metadata without changing their bytes or tag.

Before signing, the job validates all original asset hashes and the tag commit against the reviewed publication record. It verifies the signature, rejects tampered content and an incorrect signer, uploads a detached bundle without overwriting assets, then freshly downloads and verifies the published files. Document exact verification identity, scope, historical metadata semantics, and maintainer operation. README status will change only after successful live signing.

Validation: all 10 research packaging/release tests passed; Ruff, research metadata and task ledger checks, actionlint, git diff --check passed. Freshly downloaded original release assets passed the new verifier. No runtime code changes.

Integration: all 31 required checks passed for c6054464395a93f77fd5ec6452c0d323e4dc80f6. Per GOVERNANCE.md, the sole-maintainer owner exception is used for the unavailable second-person approval; this is not independent review. The owner requested digital signing in this session.
