### PR TITLE
docs(site): align Pages with signed research release and current source

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,41 +1,70 @@
-# 把 site/ 发布到 gh-pages，供 GitHub Pages 托管。
-# 产品代码仍在功能分支；不把 Pages 源设成 docs/，以免规格文档被当成站点。
-# 部署前从当前源码扫描生成 Mermaid（CLI / HTTP / import / 状态机），不是手绘。
-#
-# DEV17-D / M-C1a：Actions 钉完整 commit SHA；contents:write 仅因 peaceiris 推 gh-pages 所需。
 name: pages
 
 on:
   push:
-    branches:
-      - cursor/agentshield-w0-contracts-8eff
+    branches: [main]
     paths:
-      - "site/**"
-      - "apps/agentshield/**"
-      - "adapters/runtime/**"
-      - ".github/workflows/pages.yml"
+      - 'site/**'
+      - 'apps/agentshield/**'
+      - 'adapters/runtime/**'
+      - 'README*'
+      - 'REPRODUCIBILITY.md'
+      - 'docs/research/**'
+      - 'scripts/check_site.py'
+      - 'scripts/check_pages_action_pins.py'
+      - '.github/workflows/pages.yml'
+  pull_request:
+    paths:
+      - 'site/**'
+      - 'apps/agentshield/**'
+      - 'adapters/runtime/**'
+      - 'README*'
+      - 'REPRODUCIBILITY.md'
+      - 'docs/research/**'
+      - 'scripts/check_site.py'
+      - 'scripts/check_pages_action_pins.py'
+      - '.github/workflows/pages.yml'
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 concurrency:
-  group: github-pages
-  cancel-in-progress: true
+  group: pages-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
-  deploy:
+  build-site:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 10
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
-      - name: Generate diagrams from source
-        run: python3 site/diagrams/from_code.py
-      - name: Publish site/ to gh-pages
-        uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453  # v4.0.4 (tag v4 → commit)
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./site
-          force_orphan: true
-          enable_jekyll: false
-          commit_message: "deploy: GitHub Pages from site/"
+          persist-credentials: false
+      - name: Generate source diagrams and validate site
+        run: |
+          python3 site/diagrams/from_code.py
+          python3 scripts/check_site.py
+          python3 scripts/check_site_mermaid_vendor.py
+          python3 scripts/check_pages_action_pins.py
+      - name: Upload site artifact
+        if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
+        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4
+        with:
+          path: site
+
+  deploy:
+    if: github.repository == 'maoyadongsh/siq-agent-security' && github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
+    needs: build-site
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4

--- a/scripts/check_pages_action_pins.py
+++ b/scripts/check_pages_action_pins.py
@@ -20,7 +20,8 @@ BAD_TAG_RE = re.compile(
 
 EXPECTED = {
     "actions/checkout": "11d5960a326750d5838078e36cf38b85af677262",
-    "peaceiris/actions-gh-pages": "84c30a85c19949d7eee79c4ff27748b70285e453",
+    "actions/upload-pages-artifact": "7b1f4a764d45c48632c6b24a0339c27f5614fb0b",
+    "actions/deploy-pages": "d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e",
 }
 
 

--- a/scripts/check_site.py
+++ b/scripts/check_site.py
@@ -1,0 +1,74 @@
+"""Validate Pages links, release identity and generated source-diagram inputs."""
+
+import json
+from html.parser import HTMLParser
+from pathlib import Path
+from urllib.parse import unquote, urlsplit
+
+ROOT = Path(__file__).resolve().parents[1]
+SITE = ROOT / "site"
+
+
+class Page(HTMLParser):
+    def __init__(self, path):
+        super().__init__()
+        self.ids = set()
+        self.links = []
+        self.h1 = 0
+        self.feed(path.read_text())
+
+    def handle_starttag(self, tag, attrs):
+        attrs = dict(attrs)
+        if "id" in attrs:
+            assert attrs["id"] not in self.ids, "duplicate HTML id"
+            self.ids.add(attrs["id"])
+        self.h1 += tag == "h1"
+        for name in ("href", "src"):
+            if name in attrs:
+                self.links.append(attrs[name])
+        if tag == "img":
+            assert "alt" in attrs, "image without alt text"
+
+
+def main():
+    pages = {path: Page(path) for path in SITE.glob("*.html")}
+    for path, page in pages.items():
+        assert page.h1 == 1, f"expected one h1: {path}"
+        assert "cursor/agentshield-w0" not in path.read_text(), "obsolete branch reference"
+        for link in page.links:
+            url = urlsplit(link)
+            repo_prefix = "/maoyadongsh/siq-agent-security/"
+            if url.netloc == "github.com" and url.path.startswith(repo_prefix):
+                relative = url.path[len(repo_prefix):]
+                for prefix in ("blob/main/", "tree/main/"):
+                    if relative.startswith(prefix):
+                        assert (ROOT / unquote(relative[len(prefix):])).exists(), link
+            if url.scheme or url.netloc:
+                continue
+            target = (path.parent / unquote(url.path)).resolve() if url.path else path
+            assert target.is_relative_to(SITE), link
+            if target.is_dir():
+                target /= "index.html"
+            assert target.exists(), f"missing local link: {link} in {path.name}"
+            if url.fragment and target in pages:
+                assert unquote(url.fragment) in pages[target].ids, link
+    index = (SITE / "index.html").read_text()
+    release = json.loads((ROOT / "docs/research/evidence/release-signing-20260909.json").read_text())
+    assert release["release_tag"] in index
+    for asset in release["assets"]:
+        assert asset["url"] in index, "missing release asset link"
+    assert release["certificate_identity"] in index
+    assert release["certificate_oidc_issuer"] in index
+    assert "--mode test --port 47621" in index
+    diagrams = json.loads((SITE / "diagrams/index.json").read_text())
+    assert len(diagrams["source_sha"]) == 40
+    for field in ("cli", "http_routes", "packages", "grant_transitions", "diagrams"):
+        assert diagrams[field], f"empty source extraction: {field}"
+    for item in diagrams["diagrams"]:
+        assert (SITE / "diagrams" / item["file"]).is_file()
+    print(json.dumps({"pages": len(pages), "diagrams": len(diagrams["diagrams"]),
+                      "local_links": "passed", "release_identity": "passed"}))
+
+
+if __name__ == "__main__":
+    main()

--- a/site/404.html
+++ b/site/404.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="robots" content="noindex" />
     <title>页面不存在 · siq-agent-security</title>
-    <link rel="icon" href="./favicon.svg" type="image/svg+xml" />
+    <link rel="icon" href="./siq-shield.svg" type="image/svg+xml" />
     <link rel="stylesheet" href="./styles.css" />
   </head>
   <body>
@@ -13,7 +13,7 @@
       <div class="wrap">
         <p class="kicker">404</p>
         <h1>没有这一页。</h1>
-        <p class="lede">回到 siq-agent-security 产品页，或打开 GitHub 仓库。</p>
+        <p class="lede">回到 SIQ Agent Security 项目页，或打开 GitHub 仓库。</p>
         <div class="btn-row">
           <a class="btn btn-primary" href="./">回到首页</a>
           <a class="btn" href="https://github.com/maoyadongsh/siq-agent-security">查看源码</a>

--- a/site/architecture.html
+++ b/site/architecture.html
@@ -1,148 +1,36 @@
 <!DOCTYPE html>
 <html lang="zh-CN">
-  <head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta
-      name="description"
-      content="从 siq-agent-security 当前源码抽出的架构图与流程图：CLI、HTTP 路由、包依赖、准入结论、决策返回路径、grant 状态机。"
-    />
-    <meta name="theme-color" content="#f7f4ee" />
-    <title>从源码生成的架构图 · siq-agent-security</title>
-    <link rel="icon" href="./favicon.svg" type="image/svg+xml" />
-    <link rel="stylesheet" href="./styles.css" />
-  </head>
-  <body>
-    <a class="skip" href="#main">跳到正文</a>
-    <header class="site-header">
-      <div class="wrap nav">
-        <a class="brand" href="./">
-          <svg class="brand-mark" viewBox="0 0 32 32" fill="none" aria-hidden="true">
-            <rect width="32" height="32" rx="6" fill="#001840" />
-            <rect x="7.5" y="6.5" width="17" height="19" rx="1.5" stroke="#c9a227" stroke-width="1.5" />
-            <path d="M11 12h10M11 16h7M11 20h5" stroke="#f7f4ee" stroke-width="1.5" stroke-linecap="round" />
-            <rect x="20" y="19" width="5" height="6" fill="#7c5a0c" />
-          </svg>
-          <span class="brand-name">siq-agent-security</span>
-        </a>
-        <nav class="nav-links" aria-label="站点">
-          <a href="./architecture.html" aria-current="page">架构</a>
-          <a href="./#verdicts">结论</a>
-          <a href="./#spark">实测</a>
-          <a href="./#install">安装</a>
-          <a href="https://github.com/maoyadongsh/siq-agent-security">源码</a>
-          <a class="btn btn-primary" href="https://github.com/maoyadongsh/siq-agent-security/releases/tag/siq-agent-security-v0.2.0">v0.2.0</a>
-        </nav>
-      </div>
-    </header>
-
-    <main id="main" class="hero">
-      <div class="wrap">
-        <p class="kicker">由仓库源码扫描生成 · 不是手绘</p>
-        <h1>架构图和流程图跟着代码走。</h1>
-        <p class="lede">
-          发布 GitHub Pages 时会跑 <code>site/diagrams/from_code.py</code>，从当前 checkout 解析 CLI
-          <code>switch</code>、<code>ServeMux.HandleFunc</code>、Go <code>import</code>、<code>grant.transitions</code>、<code>builder.finish</code>
-          和 <code>Engine.evaluate</code> 的 <code>return</code>，再渲染成图。改这些源文件，图会变。
-        </p>
-        <p class="note">
-          第三方 GitDiagram 只读仓库默认分支。本仓产品在功能分支上，默认分支仍是旧的 <code>main</code>，所以不把
-          gitdiagram.com 当成事实源。
-        </p>
-        <nav class="toc-links" id="toc" aria-label="本页图"></nav>
-      </div>
-    </main>
-
-    <div class="section" id="diagrams">
-      <div class="wrap" id="diagram-root"></div>
-    </div>
-
-    <section class="section">
-      <div class="wrap">
-        <details class="extract" id="facts">
-          <summary>这次扫描抽出的标识符</summary>
-          <pre id="facts-body" tabindex="0"></pre>
-        </details>
-      </div>
-    </section>
-
-    <footer class="site-footer">
-      <div class="wrap">
-        <p>图中的节点名来自源码标识符。生成脚本：<a href="https://github.com/maoyadongsh/siq-agent-security/blob/cursor/agentshield-w0-contracts-8eff/site/diagrams/from_code.py">from_code.py</a></p>
-        <p><a href="./">产品页</a> · <a href="https://github.com/maoyadongsh/siq-agent-security">GitHub</a></p>
-      </div>
-    </footer>
-
-    <script src="./vendor/mermaid-11.4.1.min.js"></script>
-    <script type="module">
-      const root = document.getElementById("diagram-root");
-      const toc = document.getElementById("toc");
-      const facts = document.getElementById("facts-body");
-
-      try {
-        // Self-hosted pinned Mermaid (DEV17-C / M-C2) — no CDN import.
-        const mermaid = window.mermaid;
-        if (!mermaid) throw new Error("mermaid not loaded from vendor");
-        mermaid.initialize({
-          startOnLoad: false,
-          securityLevel: "strict",
-          theme: "base",
-          themeVariables: {
-            primaryColor: "#fdfcf9",
-            primaryTextColor: "#001840",
-            primaryBorderColor: "#001840",
-            lineColor: "#7c5a0c",
-            secondaryColor: "#f3eee2",
-            tertiaryColor: "#f7f4ee",
-          },
-        });
-
-        const meta = await fetch("./diagrams/index.json").then((r) => {
-          if (!r.ok) throw new Error("index.json " + r.status);
-          return r.json();
-        });
-
-        facts.textContent = [
-          "cli: " + meta.cli.join(", "),
-          "http: " + meta.http_routes.join(", "),
-          "packages: " + meta.packages.join(", "),
-          "adapters: " + meta.adapters.join(", "),
-          "grant: " + meta.grant_transitions.map((e) => e.from + "→" + e.to).join(", "),
-          "policy-exec: " + meta.policy_exec.map((e) => e.verdict + "→" + e.decision).join(", "),
-        ].join("\n\n");
-
-        const nodes = [];
-        for (const d of meta.diagrams) {
-          toc.insertAdjacentHTML(
-            "beforeend",
-            '<a href="#' + d.id + '">' + d.title + "</a>"
-          );
-          const section = document.createElement("section");
-          section.className = "section";
-          section.id = d.id;
-          section.innerHTML =
-            "<h2>" +
-            d.title +
-            "</h2>" +
-            '<p class="sources">抽出自 <code>' +
-            d.sources.join("</code>、<code>") +
-            "</code> · <a href=\"./diagrams/" +
-            d.file +
-            '">Mermaid 源</a></p>' +
-            '<div class="diagram-frame"><pre class="mermaid"></pre></div>';
-          const text = await fetch("./diagrams/" + d.file).then((r) => r.text());
-          section.querySelector(".mermaid").textContent = text;
-          root.appendChild(section);
-          nodes.push(section.querySelector(".mermaid"));
-        }
-
-        await mermaid.run({ nodes });
-      } catch (err) {
-        root.innerHTML =
-          '<p class="note" role="alert">图未能渲染：' +
-          String(err.message || err) +
-          "。可直接打开各 .mmd 源文件。</p>";
-      }
-    </script>
-  </body>
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="description" content="从 SIQ Agent Security 当前源码生成的结构摘要：CLI、HTTP 路由、Go 包依赖、准入结论与授权状态转换，附构建提交身份。" />
+  <meta name="theme-color" content="#f6f8fc" />
+  <title>源码结构与执行路径 · SIQ Agent Security</title>
+  <link rel="icon" href="./siq-shield.svg" type="image/svg+xml" />
+  <link rel="stylesheet" href="./styles.css" />
+</head>
+<body>
+  <a class="skip" href="#main">跳到正文</a>
+  <header class="site-header"><div class="wrap nav">
+    <a class="brand" href="./"><img class="brand-mark" src="./siq-shield.svg" width="36" height="36" alt="" /><span class="brand-name">SIQ Agent Security</span></a>
+    <nav class="nav-links" aria-label="站点导航"><a href="./#how-it-works">工作方式</a><a href="./#evidence">研究证据</a><a href="./architecture.html" aria-current="page">源码架构</a><a href="./#release">签名发布</a><a href="./#install">快速开始</a><a href="https://github.com/maoyadongsh/siq-agent-security">GitHub ↗</a></nav>
+  </div></header>
+  <main id="main">
+    <section class="hero"><div class="wrap">
+      <p class="eyebrow">SOURCE STRUCTURE / GENERATED ON DEPLOYMENT</p>
+      <h1>源码结构与执行路径</h1>
+      <p class="lede">每次发布站点时重新扫描当前源码，生成 CLI 子命令、HTTP 路由、Go 包依赖、准入结论与 Grant 状态转换的结构摘要。</p>
+      <p class="note">提取器使用文本匹配与固定连接模板，覆盖下方标注的文件与标识符，不是完整控制流分析或安全证明。决策中的必需 Authority 校验与策略模式分别处理；无效 Authority 不因 audit_only 或 warn 模式而放行。具体语义以<a href="https://github.com/maoyadongsh/siq-agent-security/blob/main/docs/agentshield-dev-spec-v1.md">开发规格</a>和测试为准。</p>
+      <p class="note" id="source-identity" aria-live="polite">正在读取生成时的源码身份…</p>
+      <p class="note">站点跟随 main 更新；源码预发布仍固定在 aefab111。<a href="./#release">查看发布版本与签名范围 →</a></p>
+      <nav class="toc-links" id="toc" aria-label="本页图"></nav>
+      <noscript><p>启用 JavaScript 可查看图形；也可直接阅读<a href="./diagrams/index.json">图索引</a>与<a href="https://github.com/maoyadongsh/siq-agent-security/tree/main/site/diagrams">Mermaid 源文件</a>。</p></noscript>
+    </div></section>
+    <section class="section" id="diagrams" aria-label="源码生成图"><div class="wrap" id="diagram-root"></div></section>
+    <section class="section"><div class="wrap"><details class="extract" id="facts"><summary>查看此次扫描抽出的标识符</summary><pre id="facts-body" tabindex="0"></pre></details></div></section>
+  </main>
+  <footer class="site-footer"><div class="wrap"><p>生成器：<a href="https://github.com/maoyadongsh/siq-agent-security/blob/main/site/diagrams/from_code.py">from_code.py</a> · <a href="./diagrams/index.json">生成数据</a> · <a href="./">返回项目首页</a></p></div></footer>
+  <script src="./vendor/mermaid-11.4.1.min.js"></script>
+  <script src="./architecture.js" type="module"></script>
+</body>
 </html>

--- a/site/architecture.js
+++ b/site/architecture.js
@@ -1,0 +1,75 @@
+const root = document.getElementById('diagram-root');
+const toc = document.getElementById('toc');
+const identity = document.getElementById('source-identity');
+const repository = 'https://github.com/maoyadongsh/siq-agent-security';
+
+async function fetchFile(path, json = false) {
+  const response = await fetch(path);
+  if (!response.ok) throw new Error(`${path}: HTTP ${response.status}`);
+  return json ? response.json() : response.text();
+}
+
+try {
+  const meta = await fetchFile('./diagrams/index.json', true);
+  if (!/^[a-f0-9]{40}$/.test(meta.source_sha)) throw new Error('缺少可验证的源码提交身份');
+  identity.textContent = '生成依据：';
+  const commit = document.createElement('a');
+  commit.href = `${repository}/commit/${meta.source_sha}`;
+  commit.textContent = meta.source_sha.slice(0, 12);
+  identity.append(commit, meta.source_dirty ? ' · 本地工作区含未提交修改' : ' · 干净 checkout');
+  document.getElementById('facts-body').textContent = [
+    'cli: ' + meta.cli.join(', '),
+    'http: ' + meta.http_routes.join(', '),
+    'packages: ' + meta.packages.join(', '),
+    'adapters: ' + meta.adapters.join(', '),
+    'grant: ' + meta.grant_transitions.map((e) => e.from + ' → ' + e.to).join(', '),
+    'policy-exec: ' + meta.policy_exec.map((e) => e.verdict + ' → ' + e.decision).join(', '),
+  ].join('\n\n');
+
+  const nodes = [];
+  for (const diagram of meta.diagrams) {
+    const nav = document.createElement('a');
+    nav.href = '#' + diagram.id;
+    nav.textContent = diagram.title;
+    toc.append(nav);
+    const section = document.createElement('section');
+    section.className = 'section';
+    section.id = diagram.id;
+    const title = document.createElement('h2');
+    title.textContent = diagram.title;
+    const sources = document.createElement('p');
+    sources.className = 'sources';
+    sources.textContent = '提取范围：' + diagram.sources.join(' · ') + ' · ';
+    const download = document.createElement('a');
+    download.href = './diagrams/' + diagram.file;
+    download.textContent = '查看 Mermaid 源文件';
+    sources.append(download);
+    const frame = document.createElement('div');
+    frame.className = 'diagram-frame';
+    frame.tabIndex = 0;
+    frame.setAttribute('role', 'region');
+    frame.setAttribute('aria-label', diagram.title + '，可滚动查看');
+    const pre = document.createElement('pre');
+    pre.className = 'mermaid';
+    pre.textContent = await fetchFile(download.getAttribute('href'));
+    frame.append(pre);
+    section.append(title, sources, frame);
+    root.append(section);
+    nodes.push(pre);
+  }
+
+  const mermaid = window.mermaid;
+  if (!mermaid) throw new Error('Mermaid 未能加载，请使用源文件链接');
+  mermaid.initialize({ startOnLoad: false, securityLevel: 'strict', theme: 'base', flowchart: { useMaxWidth: false }, state: { useMaxWidth: false } });
+  await mermaid.run({ nodes });
+} catch (error) {
+  if (identity.textContent.startsWith('正在')) identity.textContent = '暂时无法读取源码身份。';
+  const message = document.createElement('p');
+  message.className = 'note';
+  message.setAttribute('role', 'alert');
+  message.textContent = '图未能完整渲染：' + String(error.message || error) + '。请使用 Mermaid 源文件或图索引。';
+  const index = document.createElement('a');
+  index.href = './diagrams/index.json';
+  index.textContent = '打开图索引';
+  root.append(message, index);
+}

--- a/site/diagrams/admission.mmd
+++ b/site/diagrams/admission.mmd
@@ -1,10 +1,10 @@
 %%{init: {'theme': 'base', 'themeVariables': {
-  'primaryColor': '#fdfcf9',
-  'primaryTextColor': '#001840',
-  'primaryBorderColor': '#001840',
-  'lineColor': '#7c5a0c',
-  'secondaryColor': '#f3eee2',
-  'tertiaryColor': '#f7f4ee',
+  'primaryColor': '#eaf1fb',
+  'primaryTextColor': '#132d50',
+  'primaryBorderColor': '#43658f',
+  'lineColor': '#43658f',
+  'secondaryColor': '#f6f8fc',
+  'tertiaryColor': '#ffffff',
   'fontFamily': 'ui-sans-serif, system-ui, sans-serif'
 }}}%%
 flowchart TD

--- a/site/diagrams/cli-http.mmd
+++ b/site/diagrams/cli-http.mmd
@@ -1,10 +1,10 @@
 %%{init: {'theme': 'base', 'themeVariables': {
-  'primaryColor': '#fdfcf9',
-  'primaryTextColor': '#001840',
-  'primaryBorderColor': '#001840',
-  'lineColor': '#7c5a0c',
-  'secondaryColor': '#f3eee2',
-  'tertiaryColor': '#f7f4ee',
+  'primaryColor': '#eaf1fb',
+  'primaryTextColor': '#132d50',
+  'primaryBorderColor': '#43658f',
+  'lineColor': '#43658f',
+  'secondaryColor': '#f6f8fc',
+  'tertiaryColor': '#ffffff',
   'fontFamily': 'ui-sans-serif, system-ui, sans-serif'
 }}}%%
 flowchart TB
@@ -26,11 +26,37 @@ flowchart TB
     cli_openshell["openshell"]
     cli_release_manifest["release-manifest"]
     cli_manifest_verify["manifest-verify"]
+    cli_incomplete["incomplete"]
   end
   subgraph http["internal/server New() ServeMux"]
+    rt__v1_tasks_["/v1/tasks/"]
+    rt__v1_network_observations["/v1/network-observations"]
+    rt__v1_file_observation_recoveries["/v1/file-observation-recoveries"]
+    rt__v1_file_observations["/v1/file-observations"]
+    rt__v1_file_observations_["/v1/file-observations/"]
+    rt__v1_effect_observers["/v1/effect-observers"]
+    rt__v1_effect_observers_["/v1/effect-observers/"]
+    rt__v1_effect_evidence["/v1/effect-evidence"]
+    rt__v1_tool_effect_reports["/v1/tool-effect-reports"]
+    rt__v1_effect_evidence_["/v1/effect-evidence/"]
+    rt__v1_actions_["/v1/actions/"]
+    rt__v1_provenance_issuers["/v1/provenance-issuers"]
+    rt__v1_provenance_issuers_["/v1/provenance-issuers/"]
+    rt__v1_provenance_assertions["/v1/provenance-assertions"]
+    rt__v1_provenance_assertions_import["/v1/provenance-assertions/import"]
+    rt__v1_provenance_resolve["/v1/provenance-resolve"]
+    rt__v1_provenance_reports["/v1/provenance-reports"]
+    rt__v1_provenance_select["/v1/provenance-select"]
+    rt__v1_intents["/v1/intents"]
+    rt__v1_context_assertions["/v1/context-assertions"]
+    rt__v1_context_assertions_["/v1/context-assertions/"]
+    rt__v1_intents_["/v1/intents/"]
+    rt__v1_intent_bindings["/v1/intent-bindings"]
+    rt__v1_intent_bindings_["/v1/intent-bindings/"]
     rt__v1_status["/v1/status"]
     rt__v1_decide["/v1/decide"]
     rt__v1_observe["/v1/observe"]
+    rt__v1_hold_status["/v1/hold-status"]
     rt__v1_hold_["/v1/hold/"]
     rt__v1_receipts["/v1/receipts"]
     rt__v1_admit["/v1/admit"]
@@ -54,6 +80,7 @@ flowchart TB
     rt__v1_findings_["/v1/findings/"]
     rt__v1_audit["/v1/audit"]
     rt__v1_export["/v1/export"]
+    rt__v1_pair["/v1/pair"]
     rt__ui_config_json["/ui-config.json"]
     rt__["/"]
     rt__["/"]

--- a/site/diagrams/decide.mmd
+++ b/site/diagrams/decide.mmd
@@ -1,10 +1,10 @@
 %%{init: {'theme': 'base', 'themeVariables': {
-  'primaryColor': '#fdfcf9',
-  'primaryTextColor': '#001840',
-  'primaryBorderColor': '#001840',
-  'lineColor': '#7c5a0c',
-  'secondaryColor': '#f3eee2',
-  'tertiaryColor': '#f7f4ee',
+  'primaryColor': '#eaf1fb',
+  'primaryTextColor': '#132d50',
+  'primaryBorderColor': '#43658f',
+  'lineColor': '#43658f',
+  'secondaryColor': '#f6f8fc',
+  'tertiaryColor': '#ffffff',
   'fontFamily': 'ui-sans-serif, system-ui, sans-serif'
 }}}%%
 flowchart TD
@@ -16,12 +16,6 @@ flowchart TD
   ev --> r4["deny: 'network egress to ' + h + ' not in grant ' + g.Grant..."]
   ev --> r5["deny: 'egress exec requires granted host'"]
   ev --> r6["deny: 'credential path ' + p + ' denied (credential facts a..."]
-  ev --> r7["deny: 'write to ' + p + ' outside granted paths and cwd (de..."]
+  ev --> r7["deny: 'write to ' + p + ' outside granted paths (default de..."]
   ev --> r8["hold: 'tool ' + req.Tool + ' requires human approval per gr..."]
   ev --> r9["allow: 'granted by ' + g.GrantID"]
-  dec --> mode["switch EnforcementMode"]
-  mode --> m_audit_only["audit_only"]
-  mode --> m_warn["warn"]
-  mode --> m_default["default"]
-  m_audit_only --> advisory["non-allow → AdvisoryAction; action=allow"]
-  m_warn --> advisory

--- a/site/diagrams/from_code.py
+++ b/site/diagrams/from_code.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
 """Scan this repo's source and emit Mermaid diagrams for GitHub Pages.
 
-Nothing here is hand-laid-out architecture. Nodes and edges come from:
+Static summaries combine parsed identifiers with fixed wiring templates, not
+complete control-flow analysis. Extraction inputs:
   - CLI subcommands in cmd/agentshield/main.go
   - http.ServeMux registrations in internal/server/server.go
   - Go imports among apps/agentshield/internal/*
@@ -16,6 +17,7 @@ from __future__ import annotations
 
 import json
 import re
+import subprocess
 from collections import defaultdict
 from pathlib import Path
 
@@ -32,12 +34,12 @@ ADAPTERS_GO = INTERNAL / "adapters" / "adapters.go"
 ADAPTERS_DIR = REPO / "adapters" / "runtime"
 
 THEME = """%%{init: {'theme': 'base', 'themeVariables': {
-  'primaryColor': '#fdfcf9',
-  'primaryTextColor': '#001840',
-  'primaryBorderColor': '#001840',
-  'lineColor': '#7c5a0c',
-  'secondaryColor': '#f3eee2',
-  'tertiaryColor': '#f7f4ee',
+  'primaryColor': '#eaf1fb',
+  'primaryTextColor': '#132d50',
+  'primaryBorderColor': '#43658f',
+  'lineColor': '#43658f',
+  'secondaryColor': '#f6f8fc',
+  'tertiaryColor': '#ffffff',
   'fontFamily': 'ui-sans-serif, system-ui, sans-serif'
 }}}%%
 """
@@ -291,6 +293,9 @@ def diagram_runtime(cmds: list[str], routes: list[tuple[str, str]], adapters: li
 
 
 def main() -> None:
+    source_sha = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=REPO, text=True).strip()
+    source_dirty = bool(subprocess.check_output(
+        ["git", "status", "--porcelain", "--untracked-files=no"], cwd=REPO, text=True).strip())
     main_src = read(MAIN)
     server_src = read(SERVER)
     grant_src = read(GRANT)
@@ -362,7 +367,9 @@ def main() -> None:
 
     meta = {
         "generated_from": "site/diagrams/from_code.py",
-        "note": "Nodes and edges are parsed from the current checkout, not drawn by hand.",
+        "note": "Static source extraction with fixed wiring templates; not complete control-flow analysis.",
+        "source_sha": source_sha,
+        "source_dirty": source_dirty,
         "cli": cmds,
         "http_routes": [p for p, _ in routes],
         "packages": pkgs,

--- a/site/diagrams/grant.mmd
+++ b/site/diagrams/grant.mmd
@@ -1,10 +1,10 @@
 %%{init: {'theme': 'base', 'themeVariables': {
-  'primaryColor': '#fdfcf9',
-  'primaryTextColor': '#001840',
-  'primaryBorderColor': '#001840',
-  'lineColor': '#7c5a0c',
-  'secondaryColor': '#f3eee2',
-  'tertiaryColor': '#f7f4ee',
+  'primaryColor': '#eaf1fb',
+  'primaryTextColor': '#132d50',
+  'primaryBorderColor': '#43658f',
+  'lineColor': '#43658f',
+  'secondaryColor': '#f6f8fc',
+  'tertiaryColor': '#ffffff',
   'fontFamily': 'ui-sans-serif, system-ui, sans-serif'
 }}}%%
 stateDiagram-v2

--- a/site/diagrams/index.json
+++ b/site/diagrams/index.json
@@ -1,6 +1,8 @@
 {
   "generated_from": "site/diagrams/from_code.py",
-  "note": "Nodes and edges are parsed from the current checkout, not drawn by hand.",
+  "note": "Static source extraction with fixed wiring templates; not complete control-flow analysis.",
+  "source_sha": "537e38546ee41d47588e8f422e7554f7abbd6ed6",
+  "source_dirty": true,
   "cli": [
     "version",
     "rulepack",
@@ -18,12 +20,38 @@
     "grant",
     "openshell",
     "release-manifest",
-    "manifest-verify"
+    "manifest-verify",
+    "incomplete"
   ],
   "http_routes": [
+    "/v1/tasks/",
+    "/v1/network-observations",
+    "/v1/file-observation-recoveries",
+    "/v1/file-observations",
+    "/v1/file-observations/",
+    "/v1/effect-observers",
+    "/v1/effect-observers/",
+    "/v1/effect-evidence",
+    "/v1/tool-effect-reports",
+    "/v1/effect-evidence/",
+    "/v1/actions/",
+    "/v1/provenance-issuers",
+    "/v1/provenance-issuers/",
+    "/v1/provenance-assertions",
+    "/v1/provenance-assertions/import",
+    "/v1/provenance-resolve",
+    "/v1/provenance-reports",
+    "/v1/provenance-select",
+    "/v1/intents",
+    "/v1/context-assertions",
+    "/v1/context-assertions/",
+    "/v1/intents/",
+    "/v1/intent-bindings",
+    "/v1/intent-bindings/",
     "/v1/status",
     "/v1/decide",
     "/v1/observe",
+    "/v1/hold-status",
     "/v1/hold/",
     "/v1/receipts",
     "/v1/admit",
@@ -47,6 +75,7 @@
     "/v1/findings/",
     "/v1/audit",
     "/v1/export",
+    "/v1/pair",
     "/ui-config.json",
     "/",
     "/"
@@ -56,20 +85,32 @@
     "adapters",
     "admission",
     "canon",
+    "completion",
+    "contractvectors",
     "controlsync",
+    "display",
+    "effectevidence",
     "export",
+    "fileopen",
     "grant",
+    "intent",
     "inventory",
     "ledger",
     "openshell",
+    "pending",
+    "perfbaseline",
     "product",
+    "provenance",
     "receipt",
     "rulepack",
+    "runtimeaction",
+    "runtimeauthz",
     "server",
     "signing",
     "skillmanifest",
     "state",
     "threat",
+    "trustedcontext",
     "ui"
   ],
   "package_imports": [
@@ -87,6 +128,10 @@
     },
     {
       "from": "adapters",
+      "to": "pending"
+    },
+    {
+      "from": "adapters",
       "to": "product"
     },
     {
@@ -107,6 +152,14 @@
     },
     {
       "from": "admission",
+      "to": "display"
+    },
+    {
+      "from": "admission",
+      "to": "fileopen"
+    },
+    {
+      "from": "admission",
       "to": "rulepack"
     },
     {
@@ -116,6 +169,14 @@
     {
       "from": "admission",
       "to": "threat"
+    },
+    {
+      "from": "completion",
+      "to": "effectevidence"
+    },
+    {
+      "from": "completion",
+      "to": "runtimeaction"
     },
     {
       "from": "controlsync",
@@ -132,6 +193,34 @@
     {
       "from": "controlsync",
       "to": "signing"
+    },
+    {
+      "from": "effectevidence",
+      "to": "canon"
+    },
+    {
+      "from": "effectevidence",
+      "to": "fileopen"
+    },
+    {
+      "from": "effectevidence",
+      "to": "provenance"
+    },
+    {
+      "from": "effectevidence",
+      "to": "runtimeaction"
+    },
+    {
+      "from": "effectevidence",
+      "to": "signing"
+    },
+    {
+      "from": "export",
+      "to": "canon"
+    },
+    {
+      "from": "export",
+      "to": "display"
     },
     {
       "from": "export",
@@ -162,6 +251,30 @@
       "to": "signing"
     },
     {
+      "from": "intent",
+      "to": "canon"
+    },
+    {
+      "from": "intent",
+      "to": "completion"
+    },
+    {
+      "from": "intent",
+      "to": "provenance"
+    },
+    {
+      "from": "intent",
+      "to": "runtimeaction"
+    },
+    {
+      "from": "intent",
+      "to": "signing"
+    },
+    {
+      "from": "intent",
+      "to": "trustedcontext"
+    },
+    {
       "from": "inventory",
       "to": "admission"
     },
@@ -206,8 +319,44 @@
       "to": "state"
     },
     {
+      "from": "perfbaseline",
+      "to": "export"
+    },
+    {
+      "from": "perfbaseline",
+      "to": "intent"
+    },
+    {
+      "from": "perfbaseline",
+      "to": "ledger"
+    },
+    {
+      "from": "perfbaseline",
+      "to": "receipt"
+    },
+    {
+      "from": "perfbaseline",
+      "to": "signing"
+    },
+    {
+      "from": "provenance",
+      "to": "canon"
+    },
+    {
+      "from": "provenance",
+      "to": "runtimeaction"
+    },
+    {
+      "from": "provenance",
+      "to": "signing"
+    },
+    {
       "from": "receipt",
       "to": "canon"
+    },
+    {
+      "from": "receipt",
+      "to": "effectevidence"
     },
     {
       "from": "receipt",
@@ -215,7 +364,27 @@
     },
     {
       "from": "receipt",
+      "to": "intent"
+    },
+    {
+      "from": "receipt",
+      "to": "pending"
+    },
+    {
+      "from": "receipt",
+      "to": "provenance"
+    },
+    {
+      "from": "receipt",
       "to": "rulepack"
+    },
+    {
+      "from": "receipt",
+      "to": "runtimeaction"
+    },
+    {
+      "from": "receipt",
+      "to": "runtimeauthz"
     },
     {
       "from": "receipt",
@@ -226,7 +395,15 @@
       "to": "threat"
     },
     {
+      "from": "receipt",
+      "to": "trustedcontext"
+    },
+    {
       "from": "rulepack",
+      "to": "canon"
+    },
+    {
+      "from": "runtimeaction",
       "to": "canon"
     },
     {
@@ -239,11 +416,27 @@
     },
     {
       "from": "server",
+      "to": "canon"
+    },
+    {
+      "from": "server",
+      "to": "completion"
+    },
+    {
+      "from": "server",
+      "to": "effectevidence"
+    },
+    {
+      "from": "server",
       "to": "export"
     },
     {
       "from": "server",
       "to": "grant"
+    },
+    {
+      "from": "server",
+      "to": "intent"
     },
     {
       "from": "server",
@@ -259,7 +452,15 @@
     },
     {
       "from": "server",
+      "to": "pending"
+    },
+    {
+      "from": "server",
       "to": "product"
+    },
+    {
+      "from": "server",
+      "to": "provenance"
     },
     {
       "from": "server",
@@ -271,11 +472,19 @@
     },
     {
       "from": "server",
+      "to": "runtimeaction"
+    },
+    {
+      "from": "server",
       "to": "signing"
     },
     {
       "from": "server",
       "to": "state"
+    },
+    {
+      "from": "server",
+      "to": "trustedcontext"
     },
     {
       "from": "signing",
@@ -315,11 +524,31 @@
     },
     {
       "from": "state",
+      "to": "intent"
+    },
+    {
+      "from": "state",
       "to": "product"
+    },
+    {
+      "from": "state",
+      "to": "signing"
     },
     {
       "from": "threat",
       "to": "rulepack"
+    },
+    {
+      "from": "trustedcontext",
+      "to": "canon"
+    },
+    {
+      "from": "trustedcontext",
+      "to": "runtimeaction"
+    },
+    {
+      "from": "trustedcontext",
+      "to": "signing"
     }
   ],
   "grant_transitions": [
@@ -399,7 +628,7 @@
     },
     {
       "action": "deny",
-      "reason": "\"write to \" + p + \" outside granted paths and cwd (default deny)\""
+      "reason": "\"write to \" + p + \" outside granted paths (default deny)\""
     },
     {
       "action": "hold",
@@ -410,11 +639,7 @@
       "reason": "\"granted by \" + g.GrantID"
     }
   ],
-  "enforcement_modes_in_decide": [
-    "audit_only",
-    "warn",
-    "default"
-  ],
+  "enforcement_modes_in_decide": [],
   "policy_exec": [
     {
       "verdict": "admit",

--- a/site/diagrams/packages.mmd
+++ b/site/diagrams/packages.mmd
@@ -1,10 +1,10 @@
 %%{init: {'theme': 'base', 'themeVariables': {
-  'primaryColor': '#fdfcf9',
-  'primaryTextColor': '#001840',
-  'primaryBorderColor': '#001840',
-  'lineColor': '#7c5a0c',
-  'secondaryColor': '#f3eee2',
-  'tertiaryColor': '#f7f4ee',
+  'primaryColor': '#eaf1fb',
+  'primaryTextColor': '#132d50',
+  'primaryBorderColor': '#43658f',
+  'lineColor': '#43658f',
+  'secondaryColor': '#f6f8fc',
+  'tertiaryColor': '#ffffff',
   'fontFamily': 'ui-sans-serif, system-ui, sans-serif'
 }}}%%
 flowchart LR
@@ -12,36 +12,60 @@ flowchart LR
   adapters["adapters"]
   admission["admission"]
   canon["canon"]
+  completion["completion"]
+  contractvectors["contractvectors"]
   controlsync["controlsync"]
+  display["display"]
+  effectevidence["effectevidence"]
   export["export"]
+  fileopen["fileopen"]
   grant["grant"]
+  intent["intent"]
   inventory["inventory"]
   ledger["ledger"]
   openshell["openshell"]
+  pending["pending"]
+  perfbaseline["perfbaseline"]
   product["product"]
+  provenance["provenance"]
   receipt["receipt"]
   rulepack["rulepack"]
+  runtimeaction["runtimeaction"]
+  runtimeauthz["runtimeauthz"]
   server["server"]
   signing["signing"]
   skillmanifest["skillmanifest"]
   state["state"]
   threat["threat"]
+  trustedcontext["trustedcontext"]
   ui["ui"]
   adapterinstall --> product
   adapterinstall --> state
   adapters --> admission
+  adapters --> pending
   adapters --> product
   adapters --> receipt
   adapters --> rulepack
   adapters --> signing
   admission --> canon
+  admission --> display
+  admission --> fileopen
   admission --> rulepack
   admission --> signing
   admission --> threat
+  completion --> effectevidence
+  completion --> runtimeaction
   controlsync --> admission
   controlsync --> canon
   controlsync --> inventory
   controlsync --> signing
+  effectevidence --> canon
+  effectevidence --> fileopen
+  effectevidence --> provenance
+  effectevidence --> runtimeaction
+  effectevidence --> signing
+  export --> canon
+  export --> display
   export --> ledger
   export --> receipt
   export --> signing
@@ -49,6 +73,12 @@ flowchart LR
   grant --> admission
   grant --> canon
   grant --> signing
+  intent --> canon
+  intent --> completion
+  intent --> provenance
+  intent --> runtimeaction
+  intent --> signing
+  intent --> trustedcontext
   inventory --> admission
   inventory --> canon
   inventory --> product
@@ -60,24 +90,48 @@ flowchart LR
   ledger --> receipt
   ledger --> signing
   ledger --> state
+  perfbaseline --> export
+  perfbaseline --> intent
+  perfbaseline --> ledger
+  perfbaseline --> receipt
+  perfbaseline --> signing
+  provenance --> canon
+  provenance --> runtimeaction
+  provenance --> signing
   receipt --> canon
+  receipt --> effectevidence
   receipt --> grant
+  receipt --> intent
+  receipt --> pending
+  receipt --> provenance
   receipt --> rulepack
+  receipt --> runtimeaction
+  receipt --> runtimeauthz
   receipt --> signing
   receipt --> threat
+  receipt --> trustedcontext
   rulepack --> canon
+  runtimeaction --> canon
   server --> adapterinstall
   server --> admission
+  server --> canon
+  server --> completion
+  server --> effectevidence
   server --> export
   server --> grant
+  server --> intent
   server --> inventory
   server --> ledger
   server --> openshell
+  server --> pending
   server --> product
+  server --> provenance
   server --> receipt
   server --> rulepack
+  server --> runtimeaction
   server --> signing
   server --> state
+  server --> trustedcontext
   signing --> canon
   signing --> product
   skillmanifest --> admission
@@ -87,5 +141,10 @@ flowchart LR
   skillmanifest --> signing
   state --> admission
   state --> grant
+  state --> intent
   state --> product
+  state --> signing
   threat --> rulepack
+  trustedcontext --> canon
+  trustedcontext --> runtimeaction
+  trustedcontext --> signing

--- a/site/diagrams/runtime.mmd
+++ b/site/diagrams/runtime.mmd
@@ -1,10 +1,10 @@
 %%{init: {'theme': 'base', 'themeVariables': {
-  'primaryColor': '#fdfcf9',
-  'primaryTextColor': '#001840',
-  'primaryBorderColor': '#001840',
-  'lineColor': '#7c5a0c',
-  'secondaryColor': '#f3eee2',
-  'tertiaryColor': '#f7f4ee',
+  'primaryColor': '#eaf1fb',
+  'primaryTextColor': '#132d50',
+  'primaryBorderColor': '#43658f',
+  'lineColor': '#43658f',
+  'secondaryColor': '#f6f8fc',
+  'tertiaryColor': '#ffffff',
   'fontFamily': 'ui-sans-serif, system-ui, sans-serif'
 }}}%%
 flowchart LR

--- a/site/index.html
+++ b/site/index.html
@@ -1,288 +1,392 @@
 <!DOCTYPE html>
 <html lang="zh-CN">
-  <head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta
-      name="description"
-      content="siq-agent-security 是本机智能体的门禁：装 Skill 前给出结论，人批准最小权限，每次工具调用留下签名回执。模型不能当裁判。"
-    />
-    <meta name="theme-color" content="#f7f4ee" />
-    <title>siq-agent-security · 本机智能体的门禁</title>
-    <link rel="icon" href="./favicon.svg" type="image/svg+xml" />
-    <link rel="stylesheet" href="./styles.css" />
-  </head>
-  <body>
-    <a class="skip" href="#main">跳到正文</a>
-    <header class="site-header">
-      <div class="wrap nav">
-        <a class="brand" href="./">
-          <svg class="brand-mark" viewBox="0 0 32 32" fill="none" aria-hidden="true">
-            <rect width="32" height="32" rx="6" fill="#001840" />
-            <rect x="7.5" y="6.5" width="17" height="19" rx="1.5" stroke="#c9a227" stroke-width="1.5" />
-            <path d="M11 12h10M11 16h7M11 20h5" stroke="#f7f4ee" stroke-width="1.5" stroke-linecap="round" />
-            <rect x="20" y="19" width="5" height="6" fill="#7c5a0c" />
-          </svg>
-          <span class="brand-name">siq-agent-security</span>
-        </a>
-        <nav class="nav-links" aria-label="站点">
-          <a href="./architecture.html">架构</a>
-          <a href="#verdicts">结论</a>
-          <a href="#spark">实测</a>
-          <a href="#install">安装</a>
-          <a href="https://github.com/maoyadongsh/siq-agent-security">源码</a>
-          <a class="btn btn-primary" href="https://github.com/maoyadongsh/siq-agent-security/releases/tag/siq-agent-security-v0.2.0">v0.2.0</a>
-        </nav>
-      </div>
-    </header>
-
-    <main id="main">
-      <section class="hero">
-        <div class="wrap hero-grid">
-          <div>
-            <p class="kicker">本机门禁 · 当前 v0.2.0</p>
-            <h1>先看清本机智能体，再决定能不能装、能不能调工具。</h1>
-            <p class="lede">
-              把它当成可安装的 Skill 放进 Hermes、OpenClaw、WorkBuddy / CodeBuddy；真正做判断的是本机上的
-              <strong>siq-agent-security</strong> 程序，不是模型。模型不能宣布「这个 Skill 安全」，也不能代你点批准。
-            </p>
-            <div class="btn-row">
-              <a class="btn btn-primary" href="https://github.com/maoyadongsh/siq-agent-security">查看源码</a>
-              <a class="btn" href="https://github.com/maoyadongsh/siq-agent-security/blob/cursor/agentshield-w0-contracts-8eff/README.md">使用说明</a>
-            </div>
-          </div>
-          <aside class="receipt" aria-label="回执示例">
-            <h2>回执 · 示例</h2>
-            <p class="receipt-meta">未授予的能力默认拒绝，并留下可核验签名。下表是示意，不是真实主机数据。</p>
-            <dl class="kv">
-              <dt>结论</dt>
-              <dd><span class="badge badge-deny">deny</span></dd>
-              <dt>能力</dt>
-              <dd>web_fetch</dd>
-              <dt>原因</dt>
-              <dd>未批准出网</dd>
-              <dt>操作者</dt>
-              <dd>须人类签字</dd>
-              <dt>核验</dt>
-              <dd><span class="badge badge-pass">verify 通过</span></dd>
-            </dl>
-          </aside>
-        </div>
-      </section>
-
-      <section class="section" id="problem">
-        <div class="wrap">
-          <h2>它解决什么问题</h2>
-          <p class="section-intro">
-            能干活的智能体同时握着 Skill 目录、工具、网址、文件路径和密钥引用。来历不明的 Skill 一旦拷进目录，往往已经开始执行。市场上扫描、网关、沙箱、企业台通常是拆开的。本机缺的是一条链：发现 → 审查 → 人授权 → 调用时拦截 → 出事能核对。
-          </p>
-          <ol class="steps">
-            <li>
-              <div>
-                <h3>发现</h3>
-                <p>先盘点本机有哪些 Agent、Skill 和配置。</p>
-              </div>
-            </li>
-            <li>
-              <div>
-                <h3>审查</h3>
-                <p>装之前给出结论。静态分析，不执行被扫描内容。</p>
-              </div>
-            </li>
-            <li>
-              <div>
-                <h3>人授权</h3>
-                <p>批准权限必须留下操作者姓名。模型建议，人签字。</p>
-              </div>
-            </li>
-            <li>
-              <div>
-                <h3>拦截</h3>
-                <p>未授予的能力默认拒绝，例如没批上网就挡住 web_fetch。</p>
-              </div>
-            </li>
-            <li>
-              <div>
-                <h3>核对</h3>
-                <p>每次放行或拒绝都有签名回执，可以复核。</p>
-              </div>
-            </li>
-          </ol>
-        </div>
-      </section>
-
-      <section class="section" id="architecture">
-        <div class="wrap">
-          <h2>架构图从源码生成</h2>
-          <p class="section-intro">
-            CLI 子命令、HTTP 路由、包依赖、准入结论、运行时返回路径和 grant 状态机，都由扫描当前仓库抽出来，而不是手绘。源码一改，图跟着改。
-          </p>
-          <div class="btn-row">
-            <a class="btn btn-primary" href="./architecture.html">打开从代码生成的图</a>
-          </div>
-        </div>
-      </section>
-
-      <section class="section" id="verdicts">
-        <div class="wrap">
-          <h2>日常会看到三种结论</h2>
-          <p class="section-intro">「会用工具」和「是恶意」分开。带工具清单的官方风格 Skill 走附条件准入；隔离留给欺骗和外传。</p>
-          <div class="cards">
-            <article class="card card-quarantine">
-              <h3>隔离</h3>
-              <p>欺骗、藏指令、偷凭据再外传、文件被篡改——停，不要装。</p>
-            </article>
-            <article class="card card-conditions">
-              <h3>附条件准入</h3>
-              <p>声明了要上网、写文件、装软件——记下这些能力，等人签发，而不是一律当病毒。</p>
-            </article>
-            <article class="card card-pass">
-              <h3>通过</h3>
-              <p>能力声明干净。仍须人授权后，运行时才放行。</p>
-            </article>
-          </div>
-        </div>
-      </section>
-
-      <section class="section" id="scope">
-        <div class="wrap">
-          <h2>本机程序和企业控制面分开</h2>
-          <p class="section-intro">规则和字段约定共用，运行时分开。不另做一套账号，不自己造沙箱，也不做 HTTPS 中间人。只监听本机地址。</p>
-          <div class="table-wrap">
-            <table>
-              <thead>
-                <tr>
-                  <th scope="col"></th>
-                  <th scope="col">siq-agent-security（本机）</th>
-                  <th scope="col">企业控制面</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr>
-                  <th scope="row">给谁</th>
-                  <td>个人电脑上的智能体</td>
-                  <td>多台机器、多个团队</td>
-                </tr>
-                <tr>
-                  <th scope="row">干什么</th>
-                  <td>装 Skill 前先审查，每次调用工具留签字据</td>
-                  <td>资产台账、审批、采集、策略下发</td>
-                </tr>
-                <tr>
-                  <th scope="row">怎么跑</th>
-                  <td>一个本地程序，不用登录、不用数据库</td>
-                  <td>控制台 + API + PostgreSQL</td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
-          <p class="note">
-            当前能力表里还没有一行「已正式支持」——没有核验过的档位就不宣称。没有工具钩子就写明拦不住。文件系统和进程策略在沙箱创建时锁定，签发不得把它们标成有效。
-          </p>
-        </div>
-      </section>
-
-      <section class="section" id="spark">
-        <div class="wrap">
-          <h2>在 NVIDIA DGX Spark 上走过的路径</h2>
-          <p class="section-intro">
-            开发机是 NVIDIA DGX Spark（aarch64，Ubuntu 24.04，GPU NVIDIA GB10）。程序为原生 linux/arm64，<code>siq-agent-security 0.2.0</code>。安装脚本不从网上下载二进制。批准人均为人类，模型未代批。能力表没有改成「正式支持」。
-          </p>
-          <div class="table-wrap">
-            <table>
-              <thead>
-                <tr>
-                  <th scope="col">接入面</th>
-                  <th scope="col">实际做了什么</th>
-                  <th scope="col">明确没做 / 不宣称</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr>
-                  <th scope="row">Hermes</th>
-                  <td>恶意夹具隔离；官方风格附条件准入；人批准后未授予的 web_fetch 被拒；回执核验通过</td>
-                  <td>未配置网络沙箱时不宣称该档</td>
-                </tr>
-                <tr>
-                  <th scope="row">OpenClaw</th>
-                  <td>隔离 HOME 里写入策略与插件后可还原；恶意夹具 block、官方风格 warn</td>
-                  <td>未挂到本机正在跑的 OpenClaw 网关进程</td>
-                </tr>
-                <tr>
-                  <th scope="row">WorkBuddy / CodeBuddy</th>
-                  <td>隔离 HOME 上的真实 PreToolUse 钩子</td>
-                  <td>未驱动图形界面</td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
-          <p class="note">
-            脱敏记录在仓库
-            <a href="https://github.com/maoyadongsh/siq-agent-security/tree/cursor/agentshield-w0-contracts-8eff/docs/evidence/agentshield">docs/evidence/agentshield/</a>
-            。当前代码在分支
-            <a href="https://github.com/maoyadongsh/siq-agent-security/tree/cursor/agentshield-w0-contracts-8eff">cursor/agentshield-w0-contracts-8eff</a>
-            ，尚未合入默认分支。
-          </p>
-        </div>
-      </section>
-
-      <section class="section" id="install">
-        <div class="wrap">
-          <h2>从本仓库安装</h2>
-          <p class="section-intro">
-            目前尚未上架各平台 Skill 市场。需要 Go 1.22+ 编译本机程序。安装脚本不会从网上下载程序；找不到本机二进制就退出。
-          </p>
-          <div class="install">
-            <pre id="install-cmd" tabindex="0"><code>git clone https://github.com/maoyadongsh/siq-agent-security.git
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<meta name="description" content="SIQ Agent Security：面向 Agent Skills 的可信执行安全运行时。连接用户授权、参数来源、工具执行与效果证据，提供可复现案例和带 Sigstore 签名的源码预发布。" />
+<meta name="theme-color" content="#f6f8fc" />
+<title>SIQ Agent Security · 让 Agent 行动有边界，完成有依据</title>
+<link rel="canonical" href="https://maoyadongsh.github.io/siq-agent-security/" />
+<link rel="icon" href="./siq-shield.svg" type="image/svg+xml" />
+<link rel="stylesheet" href="./styles.css" />
+<script src="./site.js" defer>
+</script>
+</head>
+<body>
+<a class="skip" href="#main">跳到正文</a>
+<header class="site-header">
+<div class="wrap nav">
+<a class="brand" href="./">
+<img class="brand-mark" src="./siq-shield.svg" width="36" height="36" alt="" />
+<span class="brand-name">SIQ Agent Security</span>
+</a>
+<nav class="nav-links" aria-label="站点导航">
+<a href="#how-it-works">工作方式</a>
+<a href="#evidence">研究证据</a>
+<a href="./architecture.html">源码架构</a>
+<a href="#release">签名发布</a>
+<a href="#install">快速开始</a>
+<a href="https://github.com/maoyadongsh/siq-agent-security">GitHub ↗</a>
+</nav>
+</div>
+</header>
+<main id="main">
+<section class="hero">
+<div class="wrap hero-grid">
+<div>
+<p class="eyebrow">SECURE RUNTIME FOR AGENT SKILLS</p>
+<h1>让 Agent 行动有边界，<br />完成有依据。</h1>
+<p class="lede">SIQ 将用户授权、参数来源、工具执行和实际效果连接成可检查的证据链。Agent 规划任务，运行时核验动作，独立观察为任务完成提供依据。</p>
+<p class="hero-statement">Skills 给 Agent 能力，SIQ 给能力边界。</p>
+<div class="btn-row">
+<a class="btn btn-primary" href="#install">运行无密钥演示</a>
+<a class="btn" href="https://github.com/maoyadongsh/siq-agent-security">查看开源项目 ↗</a>
+</div>
+<p class="note">面向研究者、工具与适配器开发者，以及评估 Agent 权限治理的平台团队。</p>
+</div>
+<aside class="execution-chain" aria-label="授权与效果证据链示意">
+<div class="panel-heading">
+<span>TRUSTED AGENT EXECUTION</span>
+<span class="badge">流程示意</span>
+</div>
+<ol class="chain">
+<li>
+<span class="chain-index">01</span>
+<div>
+<h2>受信授权</h2>
+<p>明确任务、权限与可使用的上下文。</p>
+<code>Grant · Intent · Context</code>
+</div>
+</li>
+<li>
+<span class="chain-index">02</span>
+<div>
+<h2>动作核验</h2>
+<p>检查工具动作及其参数来源。</p>
+<code>allow · deny · hold · redact</code>
+</div>
+</li>
+<li>
+<span class="chain-index">03</span>
+<div>
+<h2>效果与完成</h2>
+<p>关联签名回执与独立效果证据。</p>
+<code>verified · blocked · incomplete</code>
+</div>
+</li>
+</ol>
+<p class="panel-note">工具自报成功、效果已发生和任务已完成，分别记录与核验。</p>
+</aside>
+</div>
+</section>
+<div class="release-strip">
+<div class="wrap release-strip-inner">
+<span>
+<strong>research-v0.1.0-rc.1</strong> · 源码预发布</span>
+<span class="signed-label">已提供 Sigstore 数字签名</span>
+<a href="#release">版本身份与验证方法 →</a>
+</div>
+</div>
+<section class="section" id="how-it-works">
+<div class="wrap">
+<p class="eyebrow">01 / AUTHORIZATION · PROVENANCE · EFFECTS</p>
+<h2>执行前、执行时、执行后，都有可核对的依据</h2>
+<p class="section-intro">以运行时检查约束已接入的执行路径，将授权事实与模型提议、结果声明分别处理。</p>
+<div class="cards">
+<article class="card">
+<span class="card-index">01 / 执行前</span>
+<h3>权限来自受信授权</h3>
+<p>静态扫描 Skill 并记录能力需求。Grant、Intent 与受信 Context 约束动作；模型输出不能自行创建有效权限。</p>
+</article>
+<article class="card">
+<span class="card-index">02 / 执行时</span>
+<h3>相同参数，仍要核验来源</h3>
+<p>在工具入口检查任务授权与参数来源，需要审批的动作在执行前重新核验。相同收件人值，也可能因来源不同得到不同决策。</p>
+</article>
+<article class="card">
+<span class="card-index">03 / 执行后</span>
+<h3>完成依赖效果证据</h3>
+<p>签名回执关联动作，独立观察文件或受控接收端的效果。缺失或冲突的证据不能被工具的“成功”返回替代。</p>
+</article>
+</div>
+</div>
+</section>
+<section class="section section-tinted" id="scenarios">
+<div class="wrap">
+<p class="eyebrow">02 / OBSERVABLE SCENARIOS</p>
+<h2>从四个可观察场景开始</h2>
+<p class="section-intro">任务是“分析仓库、生成报告并交付给指定联系人”。显式模型夹具驱动真实 SIQ 组件，可直接观察以下检查结果。</p>
+<div class="scenario-grid">
+<article class="card">
+<span class="badge badge-pass">verified</span>
+<h3>正常交付</h3>
+<p>任务授权、受信联系人以及文件和接收端效果均满足要求，完成状态通过核验。</p>
+</article>
+<article class="card">
+<span class="badge badge-deny">blocked</span>
+<h3>MCP 收件人注入</h3>
+<p>不可信工具结果提出更换收件人，运行时阻止超出授权的交付动作。</p>
+</article>
+<article class="card">
+<span class="badge">来源决定授权结果</span>
+<h3>同值、不同来源</h3>
+<p>相同收件人值分别来自可信数据库与 MCP；可信路径获准，MCP 路径被拒绝。</p>
+</article>
+<article class="card">
+<span class="badge badge-caution">incomplete</span>
+<h3>工具伪成功</h3>
+<p>工具返回成功，受控接收端却没有对应事件。任务保持未完成，等待所需效果证据。</p>
+</article>
+</div>
+<p class="note">这些场景验证指定安全路径，不是实模型遭受提示注入时的攻击成功率测量。<a href="https://github.com/maoyadongsh/siq-agent-security/blob/main/docs/research/evaluation-protocol.md">阅读评价协议 ↗</a>
+</p>
+</div>
+</section>
+<section class="section" id="evidence">
+<div class="wrap">
+<p class="eyebrow">03 / REPRODUCIBLE EVIDENCE</p>
+<h2>结果有来源，分母有边界</h2>
+<p class="section-intro">以下是已归档的特定运行结果；每项指标保留自己的语料、环境和证据记录。</p>
+<div class="table-wrap" tabindex="0" role="region" aria-label="归档研究结果">
+<table>
+<thead>
+<tr>
+<th scope="col">归档观察</th>
+<th scope="col">结果</th>
+<th scope="col">证据与范围</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<th scope="row">固定控制案例</th>
+<td>
+<strong>23 / 23</strong> 满足预期</td>
+<td>
+<a href="https://github.com/maoyadongsh/siq-agent-security/blob/main/docs/research/result-reproduction.md">开发期间的受控夹具报告</a>，不是干净发布验收。</td>
+</tr>
+<tr>
+<th scope="row">正常任务完成</th>
+<td>
+<strong>5 / 5</strong>
+</td>
+<td>同一控制报告中的全部正常任务。</td>
+</tr>
+<tr>
+<th scope="row">不安全目标实际执行</th>
+<td>
+<strong>0 / 13</strong>
+</td>
+<td>注册了不安全目标的案例，分母与正常任务不同。</td>
+</tr>
+<tr>
+<th scope="row">回执与效果封装</th>
+<td>
+<strong>318</strong> 条回执 · <strong>20</strong> 个效果封装</td>
+<td>
+<a href="https://github.com/maoyadongsh/siq-agent-security/blob/main/docs/research/evidence/reproduction-b/verification.json">独立验证程序的输出</a>。</td>
+</tr>
+<tr>
+<th scope="row">普通 Linux 浏览器复现</th>
+<td>
+<strong>9 / 9</strong> 场景通过</td>
+<td>
+<a href="https://github.com/maoyadongsh/siq-agent-security/blob/main/docs/research/evidence/reproduction-a/hosted-linux-identity.json">托管 Ubuntu 记录</a>；无需 GPU 或模型密钥。</td>
+</tr>
+<tr>
+<th scope="row">首发源码 CI</th>
+<td>
+<strong>31</strong> 项必需检查通过</td>
+<td>
+<a href="https://github.com/maoyadongsh/siq-agent-security/blob/main/docs/research/evidence/release-ci.json">对应首发提交 aefab111</a>，不是实时 CI 状态。</td>
+</tr>
+</tbody>
+</table>
+</div>
+<p class="note">历史实模型实验的成功与失败均保留在<a href="https://github.com/maoyadongsh/siq-agent-security/blob/main/docs/hackathon/benchmark-report.md">原始报告</a>中，不与固定夹具合并分母。托管 CI 复现不等于外部研究者的独立复现；当前未宣称已发表论文、DOI 或独立制品认证。</p>
+<div class="text-links">
+<a href="https://github.com/maoyadongsh/siq-agent-security/blob/main/docs/research/technical-report.md">技术报告 ↗</a>
+<a href="https://github.com/maoyadongsh/siq-agent-security/blob/main/docs/research/dataset-card.md">数据卡 ↗</a>
+<a href="https://github.com/maoyadongsh/siq-agent-security/blob/main/docs/research/claims-evidence.md">逐项结论与证据 ↗</a>
+</div>
+</div>
+</section>
+<section class="section section-tinted" id="install">
+<div class="wrap">
+<p class="eyebrow">04 / QUICK START</p>
+<h2>在普通 Linux 上，运行无模型密钥演示</h2>
+<p class="section-intro">准备 Git、Go <strong>1.26.6</strong>、Python <strong>3.12+</strong>、Node.js <strong>22 / npm</strong>。首次安装依赖需要联网；演示无需 GPU、PostgreSQL 或企业登录。</p>
+<div class="split">
+<div>
+<p>打开 <code>http://127.0.0.1:47621/demo</code>，输入终端给出的一次性配对码，选择上述场景。</p>
+<p class="note">请使用新克隆的目录，并显式保留 <code>--mode test</code>；默认 <code>demo</code> 模式会使用已配置的真实模型。需要复现首发源码时，在启动前执行 <code>git switch --detach research-v0.1.0-rc.1</code>。</p>
+<a href="https://github.com/maoyadongsh/siq-agent-security/blob/main/REPRODUCIBILITY.md">环境诊断、固定基准与三轨复现指南 ↗</a>
+</div>
+<div>
+<div class="code-heading">
+<span>演示启动命令</span>
+<button class="btn copy-btn" type="button" data-copy="#install-cmd" aria-label="复制演示启动命令" hidden>复制命令</button>
+</div>
+<pre id="install-cmd" tabindex="0">
+<code>git clone https://github.com/maoyadongsh/siq-agent-security.git
 cd siq-agent-security
-git fetch origin cursor/agentshield-w0-contracts-8eff
-git checkout cursor/agentshield-w0-contracts-8eff
 
-cd apps/agentshield
-go test ./...
-go build -trimpath -ldflags "-s -w -X main.Version=0.2.0" -o siq-agent-security ./cmd/agentshield
-mkdir -p "$HOME/.local/bin"
-install -m 0755 ./siq-agent-security "$HOME/.local/bin/siq-agent-security"</code></pre>
-            <button class="btn copy-btn" type="button" data-copy="#install-cmd">复制命令</button>
-          </div>
-          <p class="note">
-            完整步骤、适配器与演示夹具见
-            <a href="https://github.com/maoyadongsh/siq-agent-security/blob/cursor/agentshield-w0-contracts-8eff/README.md">README</a>
-            与
-            <a href="https://github.com/maoyadongsh/siq-agent-security/blob/cursor/agentshield-w0-contracts-8eff/AGENTSHIELD.md">本机操作</a>。
-            发布物：
-            <a href="https://github.com/maoyadongsh/siq-agent-security/releases/tag/siq-agent-security-v0.2.0">siq-agent-security-v0.2.0</a>。
-          </p>
-        </div>
-      </section>
-    </main>
+bash scripts/hackathon/start.sh --mode test --port 47621
+bash scripts/hackathon/healthcheck.sh
+bash scripts/hackathon/pair.sh</code>
+</pre>
+<p class="note">体验完成后停止该实例：<code>bash scripts/hackathon/stop.sh</code>。再次启动前按复现指南归档旧状态；配对码和私密状态留在本机。</p>
+</div>
+</div>
+</div>
+</section>
+<section class="section" id="components">
+<div class="wrap">
+<p class="eyebrow">05 / COMPONENTS &amp; INTEGRATION</p>
+<h2>从本地执行，到可选企业控制面</h2>
+<p class="section-intro">本地演示独立运行。更广的接入与部署范围，分别以适配器能力矩阵和企业运行手册为依据。</p>
+<div class="cards">
+<article class="card">
+<h3>Agent、Skills 与本地运行时</h3>
+<p>Secure Agent 规划任务并选择研究、报告和交付 Skills；Go 运行时负责准入、授权、管理 API、签名回执与效果核验。</p>
+<a href="https://github.com/maoyadongsh/siq-agent-security/blob/main/AGENTSHIELD.md">本地操作指南 →</a>
+</article>
+<article class="card">
+<h3>工具入口与运行时适配</h3>
+<p>Hermes、OpenClaw 与 CodeBuddy 的具体工具入口接入。存在适配器不代表所有版本、所有调用路径都受保护。</p>
+<a href="https://github.com/maoyadongsh/siq-agent-security/blob/main/docs/agentshield-capability-matrix-v1.md">接入能力矩阵 →</a>
+</article>
+<article class="card">
+<h3>企业控制面、Edge 与采集</h3>
+<p>多租户资产、证据、策略审批和 Edge 协调。Connectors 采集配置、目录、框架、进程、容器及集群信息。</p>
+<a href="https://github.com/maoyadongsh/siq-agent-security/blob/main/docs/enterprise-production-runbook-v1.md">企业部署与验证条件 →</a>
+</article>
+</div>
+<div class="architecture-link">
+<div>
+<h3>查看当前源码结构</h3>
+<p>CLI、HTTP 路由、包依赖与状态转换，由发布工作流重新扫描生成。</p>
+</div>
+<a class="btn" href="./architecture.html">打开源码架构图 →</a>
+</div>
+</div>
+</section>
+<section class="section section-tinted" id="release">
+<div class="wrap">
+<p class="eyebrow">06 / SOURCE RELEASE &amp; AUTHENTICATION</p>
+<h2>源码预发布，已提供 Sigstore 数字签名</h2>
+<p class="section-intro">
+<a href="https://github.com/maoyadongsh/siq-agent-security/releases/tag/research-v0.1.0-rc.1">research-v0.1.0-rc.1</a> 包含源码归档、版本信息和校验清单，不包含新编译的二进制或模型权重。</p>
+<div class="release-files">
+<a href="https://github.com/maoyadongsh/siq-agent-security/releases/download/research-v0.1.0-rc.1/siq-agent-security-research-v0.1.0-rc.1.tar.gz">
+<strong>源码归档</strong>
+<span>固定首发源码 · .tar.gz</span>
+</a>
+<a href="https://github.com/maoyadongsh/siq-agent-security/releases/download/research-v0.1.0-rc.1/SOURCE-INFO.json">
+<strong>SOURCE-INFO.json</strong>
+<span>版本身份与源码清单</span>
+</a>
+<a href="https://github.com/maoyadongsh/siq-agent-security/releases/download/research-v0.1.0-rc.1/SHA256SUMS">
+<strong>SHA256SUMS</strong>
+<span>源码与版本信息的文件摘要</span>
+</a>
+<a href="https://github.com/maoyadongsh/siq-agent-security/releases/download/research-v0.1.0-rc.1/SHA256SUMS.sigstore.json">
+<strong>Sigstore 签名包</strong>
+<span>签名、证书与透明日志证据</span>
+</a>
+</div>
+<p>签名绑定本仓库 GitHub Actions 发布工作流的身份，签署 <code>SHA256SUMS</code>，从而覆盖源码归档和 <code>SOURCE-INFO.json</code>。验证时必须同时核对签名身份与文件摘要。</p>
+<details class="extract">
+<summary>使用 Cosign 与 GitHub CLI 验证发布文件</summary>
+<p>安装 Cosign（已验证版本 v3.1.3）与 GitHub CLI，创建一个新的下载目录：</p>
+<div class="code-heading">
+<span>发布签名验证命令</span>
+<button class="btn copy-btn" type="button" data-copy="#verify-cmd" aria-label="复制发布签名验证命令" hidden>复制命令</button>
+</div>
+<pre id="verify-cmd" tabindex="0">
+<code>mkdir siq-release-verify
+cd siq-release-verify
+gh release download research-v0.1.0-rc.1 --repo maoyadongsh/siq-agent-security \
+  --pattern SHA256SUMS --pattern SHA256SUMS.sigstore.json \
+  --pattern SOURCE-INFO.json --pattern siq-agent-security-research-v0.1.0-rc.1.tar.gz
 
-    <footer class="site-footer">
-      <div class="wrap">
-        <p>siq-agent-security · 本机智能体门禁。数据与口径对齐仓库公开说明，不是实时扫描结果。</p>
-        <p>
-          <a href="https://github.com/maoyadongsh/siq-agent-security">GitHub</a>
-          ·
-          <a href="https://github.com/maoyadongsh/siq-agent-security/releases">Releases</a>
-        </p>
-      </div>
-    </footer>
-    <script>
-      (function () {
-        var button = document.querySelector("[data-copy]");
-        if (!button || !navigator.clipboard) return;
-        button.addEventListener("click", function () {
-          var target = document.querySelector(button.getAttribute("data-copy"));
-          if (!target) return;
-          navigator.clipboard.writeText(target.textContent).then(function () {
-            var previous = button.textContent;
-            button.textContent = "已复制";
-            window.setTimeout(function () {
-              button.textContent = previous;
-            }, 1600);
-          });
-        });
-      })();
-    </script>
-  </body>
+cosign verify-blob --bundle SHA256SUMS.sigstore.json \
+  --certificate-identity &#x27;https://github.com/maoyadongsh/siq-agent-security/.github/workflows/release-signing.yml@refs/heads/main&#x27; \
+  --certificate-oidc-issuer &#x27;https://token.actions.githubusercontent.com&#x27; \
+  SHA256SUMS &amp;&amp; sha256sum --check --strict SHA256SUMS</code>
+</pre>
+</details>
+<p class="note">源码固定在 <a href="https://github.com/maoyadongsh/siq-agent-security/commit/aefab111c7fcad9075c8f429f97c9eab519dcd22">
+<code>aefab111</code>
+</a>。2026-09-09 为原附件补充独立签名，未改写原附件；<code>official_signature=false</code> 保留首次打包的历史状态。<a href="https://github.com/maoyadongsh/siq-agent-security/blob/main/docs/research/release-authentication.md">完整验证说明与签名范围 ↗</a>
+</p>
+</div>
+</section>
+<section class="section" id="boundaries">
+<div class="wrap">
+<p class="eyebrow">07 / SECURITY BOUNDARIES</p>
+<h2>能力与证明范围一起说明</h2>
+<p class="section-intro">结合威胁模型与证据范围评估适用场景。</p>
+<div class="boundary-grid">
+<article>
+<h3>同一操作系统用户下不隔离</h3>
+<p>当前桌面模式不能阻止同 UID 恶意进程读取密钥或改写状态；Python ToolGateway 不是 OS 沙箱。</p>
+</article>
+<article>
+<h3>授权检查有接入范围</h3>
+<p>只覆盖正确接入的执行路径。来源注册与敏感级别分类仍依赖可信操作者。</p>
+</article>
+<article>
+<h3>效果观察有环境边界</h3>
+<p>文件与受控接收端的效果观察，不代表所有外部 SaaS 的交付证明；普通结果关联与独立效果证据的证明范围不同。</p>
+</article>
+<article>
+<h3>实验结果有适用范围</h3>
+<p>固定小语料与模型夹具不构成通用提示注入防护或生产安全认证；跨平台编译不等于原生平台验收。</p>
+</article>
+</div>
+<div class="text-links">
+<a href="https://github.com/maoyadongsh/siq-agent-security/blob/main/docs/threat-model.md">威胁模型 ↗</a>
+<a href="https://github.com/maoyadongsh/siq-agent-security/blob/main/SECURITY.md">私密报告安全问题 ↗</a>
+</div>
+</div>
+</section>
+<section class="section section-tinted" id="contribute">
+<div class="wrap">
+<p class="eyebrow">BUILD · REPRODUCE · REVIEW</p>
+<h2>从一条可复核的贡献开始</h2>
+<p class="section-intro">欢迎普通 Linux 复现、来源解释、夹具诊断、指标纠错，以及有来源依据的负向案例。</p>
+<div class="split">
+<div>
+<p>后续研究重点包括独立复现、长期归档和预先确定协议的新实验。</p>
+<div class="text-links">
+<a href="https://github.com/maoyadongsh/siq-agent-security/blob/main/CONTRIBUTING.md">贡献指南 ↗</a>
+<a href="https://github.com/maoyadongsh/siq-agent-security/discussions">参与讨论 ↗</a>
+</div>
+</div>
+<div class="license-panel">
+<h3>许可与引用</h3>
+<p>自有软件采用 <a href="https://github.com/maoyadongsh/siq-agent-security/blob/main/LICENSE">Apache-2.0</a>；明确列出的原创研究文档采用 <a href="https://github.com/maoyadongsh/siq-agent-security/blob/main/LICENSES/README.md">CC BY 4.0</a>。第三方材料保留各自许可。</p>
+<p>引用请使用 <a href="https://github.com/maoyadongsh/siq-agent-security/blob/main/CITATION.cff">CITATION.cff</a>，并记录实际版本、提交与语料摘要。</p>
+</div>
+</div>
+</div>
+</section>
+</main>
+<footer class="site-footer">
+<div class="wrap footer-inner">
+<div>
+<strong>SIQ Agent Security</strong>
+<p>面向 Agent Skills 的可信执行安全运行时</p>
+</div>
+<div>
+<p>内容核对：2026-09-09 · 站点与源码预发布分别记录版本身份</p>
+<p>
+<a href="https://github.com/maoyadongsh/siq-agent-security">GitHub</a> · <a href="https://github.com/maoyadongsh/siq-agent-security/blob/main/README.en.md">English documentation</a> · <a href="https://github.com/maoyadongsh/siq-agent-security/actions/workflows/pages.yml">站点发布记录</a>
+</p>
+</div>
+</div>
+</footer>
+<p class="sr-only" id="copy-status" role="status" aria-live="polite">
+</p>
+</body>
 </html>

--- a/site/site.js
+++ b/site/site.js
@@ -1,0 +1,19 @@
+document.querySelectorAll('[data-copy]').forEach((button) => {
+  if (!navigator.clipboard) return;
+  button.hidden = false;
+  button.addEventListener('click', async () => {
+    const target = document.querySelector(button.dataset.copy);
+    const status = document.getElementById('copy-status');
+    if (!target) return;
+    try {
+      await navigator.clipboard.writeText(target.textContent);
+      button.textContent = '已复制';
+      status.textContent = '命令已复制到剪贴板';
+    } catch {
+      button.textContent = '请手动复制';
+      status.textContent = '无法访问剪贴板，请选中代码手动复制';
+      target.focus();
+    }
+    window.setTimeout(() => { button.textContent = '复制命令'; }, 2000);
+  });
+});

--- a/site/styles.css
+++ b/site/styles.css
@@ -1,600 +1,146 @@
 :root {
   color-scheme: light;
-  --siq-primary: #7c5a0c;
-  --siq-primary-hover: #63490a;
-  --gold: #b58a24;
-  --gold-bright: #c9a227;
-  --ink: #001840;
-  --ink-strong: #00102e;
-  --pine: #1f3a2d;
-  --bg: #f7f4ee;
-  --card: #fdfcf9;
-  --hero: rgb(250 247 240 / 0.98);
-  --text: #12203e;
-  --text-secondary: #6c6863;
-  --nav-text: #475064;
-  --border: #e8e1d4;
-  --table-head: #f3eee2;
-  --table-row-hover: #faf7f0;
-  --approve: #15803d;
-  --caution: #b45309;
-  --reject: #a81018;
-  --radius-ctrl: 6px;
-  --radius-card: 10px;
-  --radius-panel: 12px;
-  --shadow-card: 0 1px 2px rgb(23 35 64 / 0.05);
-  --shadow-panel: 0 8px 30px rgb(23 35 64 / 0.06);
-  --focus-ring: 0 0 0 3px rgb(184 134 11 / 0.16);
-  --font-display: "Playfair Display", "Noto Serif SC", "Songti SC", "Source Han Serif SC", Georgia, serif;
-  --font-sans: Inter, -apple-system, BlinkMacSystemFont, "PingFang SC", "Microsoft YaHei", "Noto Sans CJK SC", "Segoe UI", system-ui, sans-serif;
+  --bg: #fff;
+  --surface: #f6f8fc;
+  --card: #fff;
+  --ink: #132d50;
+  --text: #24364d;
+  --muted: #54657a;
+  --accent: #2058b4;
+  --border: #dce4ef;
+  --soft: #eaf1fb;
+  --success: #216449;
+  --danger: #a32632;
+  --caution: #865407;
+  --header: rgb(255 255 255 / 96%);
+  --code-bg: #12233b;
+  --code-text: #edf3ff;
   --wrap: 72rem;
-}
-
-*,
-*::before,
-*::after {
-  box-sizing: border-box;
-}
-
-html {
-  scroll-behavior: smooth;
-}
-
-body {
-  margin: 0;
-  font-family: var(--font-sans);
-  background: var(--bg);
-  color: var(--text);
-  font-size: 1rem;
-  line-height: 1.65;
-  overflow-x: clip;
-  text-rendering: optimizeLegibility;
-  -webkit-font-smoothing: antialiased;
-  background-image:
-    linear-gradient(90deg, transparent calc(25% - 1px), rgb(23 35 64 / 0.035) 25%, transparent calc(25% + 1px)),
-    linear-gradient(90deg, transparent calc(50% - 1px), rgb(23 35 64 / 0.035) 50%, transparent calc(50% + 1px)),
-    linear-gradient(90deg, transparent calc(75% - 1px), rgb(23 35 64 / 0.035) 75%, transparent calc(75% + 1px));
-}
-
-img,
-svg {
-  display: block;
-  max-width: 100%;
-}
-
-a {
-  color: var(--siq-primary);
-  text-underline-offset: 0.18em;
-}
-
-a:hover {
-  color: var(--siq-primary-hover);
-}
-
-:focus-visible {
-  outline: 2px solid rgb(184 134 11 / 0.5);
-  outline-offset: 2px;
-  box-shadow: var(--focus-ring);
-}
-
-.skip {
-  position: absolute;
-  left: 1rem;
-  top: -4rem;
-  z-index: 20;
-  padding: 0.6rem 0.9rem;
-  background: var(--ink);
-  color: var(--card);
-  border-radius: var(--radius-ctrl);
-  text-decoration: none;
-}
-
-.skip:focus {
-  top: 0.75rem;
-  color: var(--card);
-}
-
-.wrap {
-  width: min(100% - 2rem, var(--wrap));
-  margin-inline: auto;
-}
-
-.site-header {
-  position: sticky;
-  top: 0;
-  z-index: 10;
-  background: rgb(247 244 238 / 0.92);
-  backdrop-filter: blur(10px);
-  border-bottom: 1px solid var(--border);
-}
-
-.nav {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 1rem;
-  min-height: 4rem;
-}
-
-.brand {
-  display: flex;
-  align-items: center;
-  gap: 0.7rem;
-  color: var(--ink);
-  text-decoration: none;
-  min-height: 44px;
-}
-
-.brand:hover {
-  color: var(--ink-strong);
-}
-
-.brand-mark {
-  width: 32px;
-  height: 32px;
-  flex: none;
-}
-
-.brand-name {
-  font-family: var(--font-display);
-  font-weight: 600;
-  letter-spacing: 0.012em;
-  font-size: 0.98rem;
-}
-
-.nav-links {
-  display: flex;
-  align-items: center;
-  gap: 0.25rem 0.85rem;
-  flex-wrap: wrap;
-  justify-content: flex-end;
-}
-
-.nav-links a {
-  color: var(--nav-text);
-  text-decoration: none;
-  font-size: 0.9rem;
-  font-weight: 600;
-  min-height: 44px;
-  display: inline-flex;
-  align-items: center;
-  padding-inline: 0.2rem;
-}
-
-.nav-links a:hover,
-.nav-links a[aria-current="page"] {
-  color: var(--ink);
-}
-
-.btn {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-height: 40px;
-  padding: 0 1rem;
-  border-radius: var(--radius-ctrl);
-  border: 1px solid var(--border);
-  background: transparent;
-  color: var(--text);
-  font: inherit;
-  font-size: 0.875rem;
-  font-weight: 600;
-  text-decoration: none;
-  cursor: pointer;
-  touch-action: manipulation;
-  transition: background-color 160ms ease, border-color 160ms ease, color 160ms ease;
-}
-
-.btn:hover {
-  border-color: var(--gold);
-  color: var(--siq-primary);
-}
-
-.btn-primary {
-  background: var(--ink);
-  border-color: var(--ink);
-  color: #fdfcf9;
-}
-
-.btn-primary:hover {
-  background: var(--ink-strong);
-  border-color: var(--ink-strong);
-  color: #fdfcf9;
-}
-
-.btn-row {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.65rem;
-}
-
-.hero {
-  padding: 2.75rem 0 3rem;
-}
-
-.hero-grid {
-  display: grid;
-  gap: 2rem;
-  align-items: start;
-}
-
-.kicker {
-  display: inline-flex;
-  align-items: center;
-  min-height: 1.8rem;
-  padding: 0 0.7rem;
-  border: 1px solid rgb(181 138 36 / 0.5);
-  border-radius: 999px;
-  color: var(--siq-primary);
-  font-size: 0.8125rem;
-  font-weight: 600;
-}
-
-h1,
-h2,
-h3 {
-  font-family: var(--font-display);
-  font-weight: 600;
-  letter-spacing: 0.012em;
-  text-wrap: balance;
-  color: var(--ink);
-}
-
-h1 {
-  margin: 0.85rem 0 0.9rem;
-  font-size: clamp(1.75rem, 1.15rem + 1.6vw, 2.5rem);
-  line-height: 1.22;
-}
-
-h2 {
-  margin: 0 0 0.75rem;
-  font-size: 1.25rem;
-  line-height: 1.35;
-}
-
-h3 {
-  margin: 0 0 0.4rem;
-  font-size: 1rem;
-  line-height: 1.4;
-}
-
-.lede {
-  margin: 0 0 1.25rem;
-  max-width: 40rem;
-  color: var(--text);
-  font-size: 1.05rem;
-}
-
-.lede strong {
-  font-weight: 600;
-}
-
-.receipt {
-  background: var(--hero);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-panel);
-  box-shadow: var(--shadow-panel);
-  padding: 1.15rem 1.2rem 1.25rem;
-}
-
-.receipt h2 {
-  font-size: 1rem;
-}
-
-.receipt-meta {
-  margin: 0 0 0.85rem;
-  color: var(--text-secondary);
-  font-size: 0.8125rem;
-}
-
-.kv {
-  display: grid;
-  grid-template-columns: 5.5rem 1fr;
-  gap: 0.45rem 0.75rem;
-  font-variant-numeric: tabular-nums;
-  font-size: 0.9rem;
-}
-
-.kv dt {
-  margin: 0;
-  color: var(--text-secondary);
-}
-
-.kv dd {
-  margin: 0;
-  font-weight: 600;
-}
-
-.badge {
-  display: inline-flex;
-  align-items: center;
-  border-radius: 999px;
-  padding: 0.1rem 0.55rem;
-  font-size: 0.75rem;
-  font-weight: 600;
-  letter-spacing: 0.02em;
-}
-
-.badge-deny {
-  color: var(--reject);
-  background: rgb(168 16 24 / 0.08);
-  border: 1px solid rgb(168 16 24 / 0.28);
-}
-
-.badge-pass {
-  color: var(--approve);
-  background: rgb(21 128 61 / 0.08);
-  border: 1px solid rgb(21 128 61 / 0.28);
-}
-
-.section {
-  padding: 0 0 3rem;
-}
-
-.section-intro {
-  margin: 0 0 1.25rem;
-  max-width: 42rem;
-  color: var(--text-secondary);
-}
-
-.cards {
-  display: grid;
-  gap: 0.9rem;
-}
-
-.card {
-  background: var(--card);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-card);
-  box-shadow: var(--shadow-card);
-  padding: 1.05rem 1.1rem 1.15rem;
-}
-
-.card p {
-  margin: 0;
-  color: var(--text-secondary);
-  font-size: 0.95rem;
-}
-
-.card-quarantine {
-  box-shadow: inset 2px 0 0 var(--reject), var(--shadow-card);
-}
-
-.card-conditions {
-  box-shadow: inset 2px 0 0 var(--caution), var(--shadow-card);
-}
-
-.card-pass {
-  box-shadow: inset 2px 0 0 var(--approve), var(--shadow-card);
-}
-
-.steps {
-  display: grid;
-  gap: 0.75rem;
-  padding: 0;
-  margin: 0;
-  list-style: none;
-  counter-reset: step;
-}
-
-.steps li {
-  display: grid;
-  grid-template-columns: 2rem 1fr;
-  gap: 0.75rem;
-  align-items: start;
-  background: var(--card);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-card);
-  padding: 0.9rem 1rem;
-}
-
-.steps li::before {
-  counter-increment: step;
-  content: counter(step);
-  width: 2rem;
-  height: 2rem;
-  border-radius: 999px;
-  border: 1px solid rgb(181 138 36 / 0.5);
-  color: var(--siq-primary);
-  font-family: var(--font-display);
-  font-weight: 600;
-  display: grid;
-  place-items: center;
-  font-variant-numeric: tabular-nums;
-}
-
-.steps p {
-  margin: 0;
-  color: var(--text-secondary);
-  font-size: 0.9rem;
-}
-
-.table-wrap {
-  overflow-x: auto;
-  border: 1px solid var(--border);
-  border-radius: var(--radius-card);
-  background: var(--card);
-}
-
-table {
-  width: 100%;
-  border-collapse: collapse;
-  font-variant-numeric: tabular-nums;
-  font-size: 0.9rem;
-}
-
-th,
-td {
-  padding: 0.7rem 0.9rem;
-  text-align: left;
-  vertical-align: top;
-  border-bottom: 1px solid var(--border);
-}
-
-th {
-  background: var(--table-head);
-  color: #2b3448;
-  font-family: var(--font-display);
-  font-weight: 600;
-}
-
-tbody tr:hover {
-  background: var(--table-row-hover);
-  box-shadow: inset 2px 0 0 var(--gold);
-}
-
-tbody tr:last-child th,
-tbody tr:last-child td {
-  border-bottom: 0;
-}
-
-.install {
-  position: relative;
-}
-
-pre {
-  margin: 0;
-  padding: 1rem 1.1rem 3rem;
-  overflow-x: auto;
-  background: var(--ink);
-  color: #f7f4ee;
-  border-radius: var(--radius-card);
-  font-size: 0.8125rem;
-  line-height: 1.55;
-}
-
-.copy-btn {
-  position: absolute;
-  right: 0.7rem;
-  bottom: 0.7rem;
-}
-
-.diagram-frame {
-  overflow-x: auto;
-  background: var(--card);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-panel);
-  padding: 1rem;
-}
-
-.diagram-frame .mermaid {
-  margin: 0;
-}
-
-.diagram-frame svg {
-  max-width: 100%;
-  height: auto;
-}
-
-.sources {
-  margin: 0.55rem 0 0;
-  font-size: 0.8125rem;
-  color: var(--text-secondary);
-}
-
-.sources code {
-  font-size: 0.75rem;
-}
-
-.toc-links {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.5rem 0.85rem;
-  margin: 0 0 1.5rem;
-}
-
-.toc-links a {
-  min-height: 44px;
-  display: inline-flex;
-  align-items: center;
-}
-
-.extract {
-  margin: 1rem 0 0;
-  padding: 0.85rem 1rem;
-  background: var(--card);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-card);
-}
-
-.extract summary {
-  cursor: pointer;
-  font-weight: 600;
-  min-height: 44px;
-  display: flex;
-  align-items: center;
-}
-
-.site-footer {
-  border-top: 1px solid var(--border);
-  padding: 1.4rem 0 2.2rem;
-  color: var(--text-secondary);
-  font-size: 0.8125rem;
-}
-
-.site-footer p {
-  margin: 0 0 0.4rem;
-}
-
-.site-footer a {
-  color: var(--nav-text);
-}
-
-@media (min-width: 768px) {
-  .hero-grid {
-    grid-template-columns: minmax(0, 1.15fr) minmax(16rem, 0.85fr);
-    gap: 2.5rem;
-    align-items: center;
-  }
-
-  .cards {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
-  }
-
-  .steps {
-    grid-template-columns: repeat(5, minmax(0, 1fr));
-  }
-
-  .steps li {
-    grid-template-columns: 1fr;
-    min-height: 100%;
-  }
-}
-
+  --font: -apple-system, BlinkMacSystemFont, "Segoe UI", "PingFang SC", "Microsoft YaHei", "Noto Sans CJK SC", sans-serif;
+}
+*, *::before, *::after { box-sizing: border-box; }
+html { scroll-behavior: smooth; scroll-padding-top: 6rem; }
+body { margin: 0; background: var(--bg); color: var(--text); font: 1rem/1.75 var(--font); -webkit-font-smoothing: antialiased; }
+img, svg { display: block; max-width: 100%; }
+a { color: var(--accent); text-underline-offset: .22em; }
+a:hover { text-decoration-thickness: 2px; }
+:focus-visible { outline: 3px solid var(--accent); outline-offset: 4px; }
+[hidden] { display: none !important; }
+.wrap { width: min(100% - 3rem, var(--wrap)); margin-inline: auto; }
+.skip { position: absolute; left: 1rem; top: -5rem; z-index: 30; padding: .7rem 1rem; background: var(--ink); color: var(--bg); }
+.skip:focus { top: .7rem; }
+.site-header { position: sticky; top: 0; z-index: 20; background: var(--header); border-bottom: 1px solid var(--border); }
+.nav { display: flex; align-items: center; justify-content: space-between; gap: 1rem; min-height: 5rem; }
+.brand { display: inline-flex; align-items: center; gap: .7rem; min-height: 44px; color: var(--ink); text-decoration: none; flex-shrink: 0; }
+.brand-mark { width: 36px; height: 36px; flex: none; }
+.brand-name { font-size: 1rem; font-weight: 700; letter-spacing: -.02em; }
+.nav-links { display: flex; flex-wrap: wrap; gap: .25rem 1rem; }
+.nav-links a { display: inline-flex; align-items: center; min-height: 44px; color: var(--muted); text-decoration: none; font-size: .875rem; }
+.nav-links a:hover, .nav-links a[aria-current] { color: var(--accent); }
+h1, h2, h3 { color: var(--ink); line-height: 1.35; text-wrap: balance; }
+h1 { margin: 1rem 0 1.5rem; font-size: clamp(2rem, 3.4vw, 3.2rem); letter-spacing: -.045em; }
+h2 { margin: 0 0 1rem; font-size: clamp(1.55rem, 2.25vw, 2rem); letter-spacing: -.025em; }
+h3 { margin: .5rem 0 .75rem; font-size: 1.1rem; }
+p { margin: 0 0 1rem; }
+.eyebrow { margin: 0 0 1.1rem; color: var(--accent); font-size: .75rem; font-weight: 700; letter-spacing: .14em; }
+.hero { padding: 5.5rem 0 4.5rem; background: var(--surface); }
+.hero-grid { display: grid; grid-template-columns: minmax(0, 1.2fr) minmax(0, 1fr); gap: 3.5rem; align-items: center; }
+.lede { font-size: 1.075rem; color: var(--muted); max-width: 40rem; }
+.hero-statement { margin: 1.5rem 0; color: var(--ink); font-weight: 600; }
+.btn-row, .text-links { display: flex; flex-wrap: wrap; gap: .75rem 1rem; align-items: center; }
+.btn { display: inline-flex; justify-content: center; align-items: center; min-height: 44px; padding: .55rem 1.15rem; border: 1px solid var(--border); border-radius: 6px; background: var(--card); color: var(--ink); text-decoration: none; font: 600 .9rem/1.5 var(--font); cursor: pointer; touch-action: manipulation; transition: background-color 180ms, border-color 180ms; }
+.btn:hover { border-color: var(--accent); text-decoration: none; }
+.btn-primary { background: var(--accent); border-color: var(--accent); color: #fff; }
+.btn-primary:hover { background: #17458e; }
+.text-links a { display: inline-flex; align-items: center; min-height: 44px; }
+.note { margin: 1.2rem 0 0; font-size: .875rem; color: var(--muted); }
+.execution-chain { padding: 1.5rem; border: 1px solid var(--border); border-radius: 14px; background: var(--card); box-shadow: 0 16px 50px rgb(19 45 80 / 6%); }
+.panel-heading { display: flex; align-items: center; justify-content: space-between; gap: .5rem; color: var(--muted); font-size: .65rem; letter-spacing: .08em; font-weight: 700; }
+.chain { margin: 1.6rem 0; padding: 0; list-style: none; }
+.chain li { display: flex; gap: 1rem; padding: 1rem 0; }
+.chain li + li { border-top: 1px solid var(--border); }
+.chain-index { flex: none; display: grid; place-items: center; width: 2.5rem; height: 2.5rem; border-radius: 8px; background: var(--soft); color: var(--accent); font-size: .85rem; font-weight: 700; }
+.chain h2 { margin: 0 0 .35rem; font-size: 1.05rem; }
+.chain p { margin: 0 0 .4rem; font-size: .9rem; }
+.chain code { color: var(--muted); font-size: .75rem; }
+.panel-note { margin: 0; color: var(--muted); font-size: .8rem; border-top: 1px solid var(--border); padding-top: 1rem; }
+.badge { display: inline-flex; padding: .2rem .6rem; border: 1px solid var(--border); border-radius: 5px; background: var(--soft); color: var(--accent); font-size: .75rem; font-weight: 600; letter-spacing: 0; }
+.badge-pass, .signed-label { color: var(--success); }
+.badge-deny { color: var(--danger); }
+.badge-caution { color: var(--caution); }
+.release-strip { border-block: 1px solid var(--border); }
+.release-strip-inner { display: flex; flex-wrap: wrap; justify-content: space-between; gap: .5rem 1.5rem; padding-block: 1.2rem; font-size: .875rem; }
+.section { padding: 4.5rem 0; }
+.section-tinted { background: var(--surface); }
+.section-intro { max-width: 50rem; color: var(--muted); margin-bottom: 2rem; }
+.cards { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 1.25rem; }
+.card { padding: 1.5rem; border: 1px solid var(--border); border-radius: 10px; background: var(--card); }
+.card p { color: var(--muted); font-size: .95rem; margin-bottom: 0; }
+.card > a { display: inline-flex; align-items: center; min-height: 44px; margin-top: 1rem; font-size: .875rem; }
+.card-index { color: var(--accent); font-size: .75rem; font-weight: 700; }
+.card h3 { margin-top: 1rem; }
+.scenario-grid, .boundary-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 1.25rem; }
+.boundary-grid article { border-top: 1px solid var(--border); padding-top: 1rem; }
+.boundary-grid p { color: var(--muted); }
+.table-wrap { overflow: auto; border: 1px solid var(--border); border-radius: 10px; }
+table { width: 100%; border-collapse: collapse; font-size: .9rem; font-variant-numeric: tabular-nums; background: var(--card); }
+th, td { padding: 1rem 1.25rem; text-align: left; vertical-align: top; border-bottom: 1px solid var(--border); }
+thead th { color: var(--muted); background: var(--surface); font-size: .8rem; }
+tbody th { width: 24%; font-weight: 600; }
+tbody tr:last-child > * { border-bottom: 0; }
+.split { display: grid; grid-template-columns: minmax(0, .85fr) minmax(0, 1.15fr); gap: 2.5rem; }
+.split > *, .hero-grid > * { min-width: 0; }
+code { font-family: ui-monospace, SFMono-Regular, Consolas, monospace; font-size: .875em; overflow-wrap: anywhere; }
+pre { margin: 0; padding: 1.2rem; overflow: auto; border-radius: 0 0 8px 8px; background: var(--code-bg); color: var(--code-text); font: .8rem/1.8 ui-monospace, SFMono-Regular, Consolas, monospace; }
+pre code { font-size: inherit; overflow-wrap: normal; }
+.code-heading { display: flex; justify-content: space-between; align-items: center; gap: .5rem; padding: .55rem .75rem .55rem 1.2rem; border-radius: 8px 8px 0 0; background: var(--code-bg); color: var(--code-text); font-size: .8rem; border-bottom: 1px solid #3a4c66; }
+.copy-btn { min-height: 44px; padding: .35rem .7rem; background: #243c5d; color: #f1f5ff; border-color: #4c6485; font-size: .75rem; }
+.architecture-link { display: flex; justify-content: space-between; align-items: center; gap: 1.5rem; margin-top: 2rem; padding: 1.5rem; border: 1px solid var(--border); border-radius: 10px; }
+.architecture-link p { margin: 0; color: var(--muted); }
+.architecture-link .btn { flex-shrink: 0; }
+.release-files { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: .9rem; margin-bottom: 1.5rem; }
+.release-files a { padding: 1.2rem; border: 1px solid var(--border); border-radius: 8px; background: var(--card); text-decoration: none; overflow-wrap: anywhere; }
+.release-files a:hover { border-color: var(--accent); }
+.release-files strong, .release-files span { display: block; }
+.release-files strong { font-size: .9rem; }
+.release-files span { margin-top: .5rem; font-size: .8rem; color: var(--muted); }
+.extract { margin-top: 1.5rem; padding: .65rem 1.2rem; border: 1px solid var(--border); border-radius: 8px; background: var(--card); }
+.extract summary { cursor: pointer; font-weight: 600; padding-block: .7rem; min-height: 44px; }
+.extract[open] summary { margin-bottom: .6rem; }
+.extract pre { margin-bottom: .7rem; }
+.license-panel { padding-left: 2rem; border-left: 1px solid var(--border); }
+.site-footer { padding: 2rem 0; border-top: 1px solid var(--border); color: var(--muted); font-size: .8rem; }
+.footer-inner { display: flex; justify-content: space-between; gap: 2rem; }
+.site-footer p { margin: .4rem 0; }
+.sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0,0,0,0); white-space: nowrap; border: 0; }
+.toc-links { display: flex; flex-wrap: wrap; gap: .5rem 1.25rem; margin-top: 1.5rem; }
+.toc-links a { display: inline-flex; align-items: center; min-height: 44px; }
+.sources { color: var(--muted); font-size: .8rem; overflow-wrap: anywhere; }
+.diagram-frame { overflow: auto; max-height: 44rem; padding: 1.2rem; background: #fff; border: 1px solid var(--border); border-radius: 10px; }
+.diagram-frame pre { padding: 0; background: transparent; color: #132d50; border-radius: 0; }
+.diagram-frame svg { max-width: none; }
+#diagrams .section { padding: 0 0 3rem; }
+@media (prefers-color-scheme: dark) {
+  :root { color-scheme: dark; --bg: #101925; --surface: #142030; --card: #192638; --ink: #e5edf9; --text: #cfdaeb; --muted: #a5b5cd; --accent: #94bcff; --border: #34455d; --soft: #243b5a; --success: #8fd8b4; --danger: #ffb4bb; --caution: #e8c386; --header: rgb(16 25 37 / 97%); }
+  .btn-primary { background: #3068c3; border-color: #3068c3; color: #fff; }
+  .btn-primary:hover { background: #2556a5; }
+}
+@media (max-width: 1050px) { .nav { flex-wrap: wrap; padding-block: .75rem; gap: .25rem; } .nav-links { gap: .2rem 1.2rem; } }
 @media (max-width: 767px) {
-  body {
-    background-image: none;
-  }
-
-  .nav {
-    align-items: flex-start;
-    padding-block: 0.55rem;
-  }
-
-  .nav-links {
-    justify-content: flex-start;
-  }
-
-  th,
-  td {
-    padding: 0.65rem 0.7rem;
-  }
+  html { scroll-padding-top: 1rem; }
+  .site-header { position: static; }
+  .wrap { width: min(100% - 2rem, var(--wrap)); }
+  .hero { padding: 3rem 0; }
+  .hero-grid, .split { grid-template-columns: minmax(0, 1fr); gap: 2rem; }
+  .cards, .scenario-grid, .boundary-grid { grid-template-columns: minmax(0, 1fr); }
+  .release-files { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .section { padding: 3rem 0; }
+  .eyebrow { font-size: .7rem; letter-spacing: .08em; }
+  .card { padding: 1.3rem; }
+  .execution-chain { padding: 1.1rem; }
+  .architecture-link, .footer-inner { flex-direction: column; align-items: flex-start; }
+  .license-panel { padding-left: 0; border-left: 0; border-top: 1px solid var(--border); padding-top: 1rem; }
+  th, td { padding: .85rem; min-width: 8rem; }
+  .table-wrap table { min-width: 36rem; }
 }
-
-@media (pointer: coarse) {
-  .btn,
-  .copy-btn {
-    min-height: 44px;
-  }
-}
-
-@media (prefers-reduced-motion: reduce) {
-  html {
-    scroll-behavior: auto;
-  }
-
-  .btn,
-  tbody tr {
-    transition: none;
-  }
-}
+@media (prefers-reduced-motion: reduce) { html { scroll-behavior: auto; } *, *::before, *::after { transition: none !important; } }


### PR DESCRIPTION
## Problem and behavior

The public Pages site still describes the old v0.2.0 development branch and unsigned-era release state. Refresh it around the current research source prerelease, its immutable source identity, the added Sigstore signature, runnable test-mode quickstart and the actual evidence and limitations.

The architecture view regenerates from the checked-out source and identifies that commit, distinguishing parsed identifiers and fixed wiring templates from complete control-flow analysis. Pages now validates pull requests and deploys only canonical `main` through the official Pages artifact and OIDC deployment actions, pinned to reviewed commit SHAs.

## Validation

- Local site links, release asset identities, pinned actions and vendored Mermaid checks pass; actionlint, Ruff for the new checker and git diff checks pass.
- Browser previews pass in light/dark at 375, 768, 1024 and 1440 px without page overflow. All six diagrams render at mobile/desktop widths.
- Copy command success and clipboard rejection, and unavailable diagram-index fallback were exercised.
- Runtime behavior, release source tag and existing signed release assets are unchanged.

All 31 required repository checks and the new Pages build check passed on `0e4d3f344428a0810d13e1d30f2a4c89ad0852dc`. The Pages repository setting will be migrated from branch publishing to GitHub Actions for the first deployment.

## Maintainer-only merge record

Following GOVERNANCE.md, the sole maintainer is using the documented owner-only merge exception because no second maintainer is available. All 31 required checks and the Pages build have passed on the exact reviewed head above. This records the exception; it is not an independent approval. Branch protection requirements remain configured. The user explicitly authorized bringing the public project Pages up to date and deploying it.
