### PR TITLE
site: 默认完整展示架构图并内置缩放工具

### DIFF
--- a/site/architecture.js
+++ b/site/architecture.js
@@ -18,43 +18,83 @@ function addDiagramControls(canvas, frame, title) {
   const controls = document.createElement('div');
   controls.className = 'diagram-controls';
   controls.setAttribute('role', 'group');
-  controls.setAttribute('aria-label', title + '的显示比例');
+  controls.setAttribute('aria-label', title + '的查看工具');
   const percentage = document.createElement('output');
   percentage.className = 'diagram-scale';
+  percentage.setAttribute('aria-label', '显示比例');
   percentage.setAttribute('aria-live', 'polite');
   let scale = 1;
-  let sizing = 'readable';
+  let sizing = 'fit';
 
-  function button(label, action) {
+  function button(label, path, action) {
     const control = document.createElement('button');
     control.type = 'button';
-    control.textContent = label;
+    control.title = label;
+    control.setAttribute('aria-label', label);
+    if (path) {
+      const icon = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+      icon.setAttribute('viewBox', '0 0 24 24');
+      icon.setAttribute('aria-hidden', 'true');
+      const shape = document.createElementNS(icon.namespaceURI, 'path');
+      shape.setAttribute('d', path);
+      icon.append(shape);
+      control.append(icon);
+    } else {
+      control.textContent = '1:1';
+    }
     control.addEventListener('click', action);
     return control;
   }
 
+  function availableSpace() {
+    const style = getComputedStyle(frame);
+    const left = parseFloat(style.paddingLeft);
+    const top = parseFloat(style.paddingTop);
+    return {
+      left, top,
+      width: frame.clientWidth - left - parseFloat(style.paddingRight),
+      height: frame.clientHeight - top - parseFloat(style.paddingBottom),
+    };
+  }
+
+  function fitScale() {
+    const space = availableSpace();
+    return Math.min(1, space.width / width, space.height / height);
+  }
+
+  function sizeViewport() {
+    const style = getComputedStyle(frame);
+    const availableWidth = frame.parentElement.clientWidth - parseFloat(style.paddingLeft) - parseFloat(style.paddingRight);
+    const fittedHeight = height * Math.min(1, availableWidth / width);
+    frame.style.setProperty('--diagram-height', `${fittedHeight + parseFloat(style.paddingTop) + parseFloat(style.paddingBottom)}px`);
+  }
+
   function resize(next, reset = false) {
-    const centerX = (frame.scrollLeft + frame.clientWidth / 2) / scale;
-    const centerY = (frame.scrollTop + frame.clientHeight / 2) / scale;
-    scale = Math.min(3, Math.max(0.02, next));
+    const space = availableSpace();
+    const viewport = frame.getBoundingClientRect();
+    const before = svg.getBoundingClientRect();
+    const centerX = viewport.left + frame.clientLeft + space.left + space.width / 2;
+    const centerY = viewport.top + frame.clientTop + space.top + space.height / 2;
+    const anchorX = (centerX - before.left) / scale;
+    const anchorY = (centerY - before.top) / scale;
+    const minimum = Math.min(0.02, fitScale());
+    scale = Math.min(3, Math.max(minimum, next));
     svg.style.width = `${width * scale}px`;
     svg.style.height = `${height * scale}px`;
     percentage.textContent = `${Math.round(scale * 100)}%`;
-    smaller.disabled = scale <= 0.02;
+    smaller.disabled = scale <= minimum;
     larger.disabled = scale >= 3;
-    frame.scrollLeft = reset ? 0 : centerX * scale - frame.clientWidth / 2;
-    frame.scrollTop = reset ? 0 : centerY * scale - frame.clientHeight / 2;
-  }
-
-  function widthScale() {
-    const style = getComputedStyle(frame);
-    const available = frame.clientWidth - parseFloat(style.paddingLeft) - parseFloat(style.paddingRight);
-    return Math.min(1, available / width);
+    const after = svg.getBoundingClientRect();
+    frame.scrollLeft = reset ? 0 : frame.scrollLeft + after.left + anchorX * scale - centerX;
+    frame.scrollTop = reset ? 0 : frame.scrollTop + after.top + anchorY * scale - centerY;
+    frame.classList.toggle('is-pannable', frame.scrollWidth > frame.clientWidth + 1 || frame.scrollHeight > frame.clientHeight + 1);
   }
 
   function fit() {
     sizing = 'fit';
-    resize(widthScale(), true);
+    resize(fitScale(), true);
+    // Reclaim any space freed by the scrollbars after returning from a zoomed view.
+    if (fitScale() !== scale) resize(fitScale(), true);
   }
 
   function zoom(multiplier) {
@@ -62,36 +102,65 @@ function addDiagramControls(canvas, frame, title) {
     resize(scale * multiplier);
   }
 
-  const fitButton = button('适应宽度', fit);
-  const original = button('原始尺寸', () => {
+  const fitButton = button('显示全图', 'M8 3H3v5m13-5h5v5M3 16v5h5m13-5v5h-5', fit);
+  const original = button('原始尺寸', null, () => {
     sizing = 'manual';
     resize(1, true);
   });
-  const smaller = button('缩小', () => zoom(1 / 1.25));
-  const larger = button('放大', () => zoom(1.25));
+  const smaller = button('缩小', 'M5 12h14', () => zoom(1 / 1.25));
+  const larger = button('放大', 'M12 5v14m-7-7h14', () => zoom(1.25));
   const presets = document.createElement('div');
   presets.className = 'diagram-presets';
   presets.append(fitButton, original);
   const zoomControls = document.createElement('div');
   zoomControls.className = 'diagram-zoom';
   zoomControls.append(smaller, percentage, larger);
-  controls.append(presets, zoomControls);
-  frame.before(controls);
+  controls.append(zoomControls, presets);
+  frame.parentElement.append(controls);
 
   const hint = document.createElement('p');
   hint.className = 'diagram-hint';
-  hint.textContent = '适应宽度可看整体，原始尺寸可看细节；聚焦图形后可用方向键滚动。';
-  frame.after(hint);
-  // Dense graphs need a readable starting scale; fitting the entire inventory
-  // into a phone screen would otherwise reduce its labels to a few pixels.
-  resize(Math.max(0.75, widthScale()), true);
+  hint.textContent = '默认显示全图；放大后可拖动或用方向键查看细节。';
+  frame.parentElement.after(hint);
+
+  let drag;
+  frame.addEventListener('pointerdown', (event) => {
+    // Touch devices retain native scrolling, including normal page scrolling.
+    if (event.pointerType !== 'mouse' || event.button !== 0 || !frame.classList.contains('is-pannable')) return;
+    event.preventDefault();
+    frame.focus({ preventScroll: true });
+    drag = { id: event.pointerId, x: event.clientX, y: event.clientY, left: frame.scrollLeft, top: frame.scrollTop };
+    frame.setPointerCapture(event.pointerId);
+    frame.classList.add('is-dragging');
+  });
+  frame.addEventListener('pointermove', (event) => {
+    if (!drag || event.pointerId !== drag.id) return;
+    frame.scrollLeft = drag.left + drag.x - event.clientX;
+    frame.scrollTop = drag.top + drag.y - event.clientY;
+  });
+  function endDrag(event) {
+    if (!drag || event.pointerId !== drag.id) return;
+    drag = undefined;
+    frame.classList.remove('is-dragging');
+    if (frame.hasPointerCapture(event.pointerId)) frame.releasePointerCapture(event.pointerId);
+  }
+  frame.addEventListener('pointerup', endDrag);
+  frame.addEventListener('pointercancel', endDrag);
+  frame.addEventListener('lostpointercapture', endDrag);
+
+  sizeViewport();
+  fit();
   let previousWidth = frame.clientWidth;
+  let previousHeight = frame.clientHeight;
   new ResizeObserver(() => {
+    sizeViewport();
     const currentWidth = frame.clientWidth;
-    if (currentWidth !== previousWidth) {
+    const currentHeight = frame.clientHeight;
+    if (currentWidth !== previousWidth || currentHeight !== previousHeight) {
       previousWidth = currentWidth;
+      previousHeight = currentHeight;
       if (sizing === 'fit') fit();
-      if (sizing === 'readable') resize(Math.max(0.75, widthScale()), true);
+      else resize(scale);
     }
   }).observe(frame);
 }
@@ -131,6 +200,8 @@ try {
     download.href = './diagrams/' + diagram.file;
     download.textContent = '查看 Mermaid 源文件';
     sources.append(download);
+    const viewer = document.createElement('div');
+    viewer.className = 'diagram-viewer';
     const frame = document.createElement('div');
     frame.className = 'diagram-frame';
     frame.tabIndex = 0;
@@ -143,7 +214,8 @@ try {
     canvas.textContent = await fetchFile(download.getAttribute('href'));
     canvas.style.visibility = 'hidden';
     frame.append(canvas);
-    section.append(title, sources, frame);
+    viewer.append(frame);
+    section.append(title, sources, viewer);
     root.append(section);
     diagrams.push({ canvas, frame, title: diagram.title });
   }

--- a/site/architecture.js
+++ b/site/architecture.js
@@ -9,6 +9,93 @@ async function fetchFile(path, json = false) {
   return json ? response.json() : response.text();
 }
 
+function addDiagramControls(canvas, frame, title) {
+  const svg = canvas.querySelector('svg');
+  if (!svg) return;
+  const { width, height } = svg.viewBox.baseVal;
+  if (!(width > 0 && height > 0)) return;
+
+  const controls = document.createElement('div');
+  controls.className = 'diagram-controls';
+  controls.setAttribute('role', 'group');
+  controls.setAttribute('aria-label', title + '的显示比例');
+  const percentage = document.createElement('output');
+  percentage.className = 'diagram-scale';
+  percentage.setAttribute('aria-live', 'polite');
+  let scale = 1;
+  let sizing = 'readable';
+
+  function button(label, action) {
+    const control = document.createElement('button');
+    control.type = 'button';
+    control.textContent = label;
+    control.addEventListener('click', action);
+    return control;
+  }
+
+  function resize(next, reset = false) {
+    const centerX = (frame.scrollLeft + frame.clientWidth / 2) / scale;
+    const centerY = (frame.scrollTop + frame.clientHeight / 2) / scale;
+    scale = Math.min(3, Math.max(0.02, next));
+    svg.style.width = `${width * scale}px`;
+    svg.style.height = `${height * scale}px`;
+    percentage.textContent = `${Math.round(scale * 100)}%`;
+    smaller.disabled = scale <= 0.02;
+    larger.disabled = scale >= 3;
+    frame.scrollLeft = reset ? 0 : centerX * scale - frame.clientWidth / 2;
+    frame.scrollTop = reset ? 0 : centerY * scale - frame.clientHeight / 2;
+  }
+
+  function widthScale() {
+    const style = getComputedStyle(frame);
+    const available = frame.clientWidth - parseFloat(style.paddingLeft) - parseFloat(style.paddingRight);
+    return Math.min(1, available / width);
+  }
+
+  function fit() {
+    sizing = 'fit';
+    resize(widthScale(), true);
+  }
+
+  function zoom(multiplier) {
+    sizing = 'manual';
+    resize(scale * multiplier);
+  }
+
+  const fitButton = button('适应宽度', fit);
+  const original = button('原始尺寸', () => {
+    sizing = 'manual';
+    resize(1, true);
+  });
+  const smaller = button('缩小', () => zoom(1 / 1.25));
+  const larger = button('放大', () => zoom(1.25));
+  const presets = document.createElement('div');
+  presets.className = 'diagram-presets';
+  presets.append(fitButton, original);
+  const zoomControls = document.createElement('div');
+  zoomControls.className = 'diagram-zoom';
+  zoomControls.append(smaller, percentage, larger);
+  controls.append(presets, zoomControls);
+  frame.before(controls);
+
+  const hint = document.createElement('p');
+  hint.className = 'diagram-hint';
+  hint.textContent = '适应宽度可看整体，原始尺寸可看细节；聚焦图形后可用方向键滚动。';
+  frame.after(hint);
+  // Dense graphs need a readable starting scale; fitting the entire inventory
+  // into a phone screen would otherwise reduce its labels to a few pixels.
+  resize(Math.max(0.75, widthScale()), true);
+  let previousWidth = frame.clientWidth;
+  new ResizeObserver(() => {
+    const currentWidth = frame.clientWidth;
+    if (currentWidth !== previousWidth) {
+      previousWidth = currentWidth;
+      if (sizing === 'fit') fit();
+      if (sizing === 'readable') resize(Math.max(0.75, widthScale()), true);
+    }
+  }).observe(frame);
+}
+
 try {
   const meta = await fetchFile('./diagrams/index.json', true);
   if (!/^[a-f0-9]{40}$/.test(meta.source_sha)) throw new Error('缺少可验证的源码提交身份');
@@ -26,7 +113,7 @@ try {
     'policy-exec: ' + meta.policy_exec.map((e) => e.verdict + ' → ' + e.decision).join(', '),
   ].join('\n\n');
 
-  const nodes = [];
+  const diagrams = [];
   for (const diagram of meta.diagrams) {
     const nav = document.createElement('a');
     nav.href = '#' + diagram.id;
@@ -49,13 +136,16 @@ try {
     frame.tabIndex = 0;
     frame.setAttribute('role', 'region');
     frame.setAttribute('aria-label', diagram.title + '，可滚动查看');
-    const pre = document.createElement('pre');
-    pre.className = 'mermaid';
-    pre.textContent = await fetchFile(download.getAttribute('href'));
-    frame.append(pre);
+    // A code-block font changes label widths after Mermaid measures them.
+    // Keep the rendered diagram in the same font context as the renderer.
+    const canvas = document.createElement('div');
+    canvas.className = 'mermaid diagram-canvas';
+    canvas.textContent = await fetchFile(download.getAttribute('href'));
+    canvas.style.visibility = 'hidden';
+    frame.append(canvas);
     section.append(title, sources, frame);
     root.append(section);
-    nodes.push(pre);
+    diagrams.push({ canvas, frame, title: diagram.title });
   }
 
   const mermaid = window.mermaid;
@@ -85,12 +175,17 @@ try {
       clusterBkg: '#faf7f0',
       clusterBorder: '#e8e1d4',
       titleColor: '#001840',
-      fontFamily: 'Inter, "PingFang SC", "Microsoft YaHei", system-ui, sans-serif',
+      fontFamily: getComputedStyle(root).fontFamily,
     },
-    flowchart: { useMaxWidth: false },
+    flowchart: { useMaxWidth: false, nodeSpacing: 20, rankSpacing: 28, padding: 10 },
     state: { useMaxWidth: false },
   });
-  await mermaid.run({ nodes });
+  await document.fonts.ready;
+  await mermaid.run({ nodes: diagrams.map(({ canvas }) => canvas) });
+  for (const { canvas, frame, title } of diagrams) {
+    canvas.style.visibility = '';
+    addDiagramControls(canvas, frame, title);
+  }
 } catch (error) {
   if (identity.textContent.startsWith('正在')) identity.textContent = '暂时无法读取源码身份。';
   const message = document.createElement('p');

--- a/site/diagrams/admission.mmd
+++ b/site/diagrams/admission.mmd
@@ -1,12 +1,3 @@
-%%{init: {'theme': 'base', 'themeVariables': {
-  'primaryColor': '#eaf1fb',
-  'primaryTextColor': '#132d50',
-  'primaryBorderColor': '#43658f',
-  'lineColor': '#43658f',
-  'secondaryColor': '#f6f8fc',
-  'tertiaryColor': '#ffffff',
-  'fontFamily': 'ui-sans-serif, system-ui, sans-serif'
-}}}%%
 flowchart TD
   start["admission.Admit(path)"] --> finish["builder.finish()"]
   finish --> def["default verdict = admit"]

--- a/site/diagrams/cli-http.mmd
+++ b/site/diagrams/cli-http.mmd
@@ -1,89 +1,176 @@
-%%{init: {'theme': 'base', 'themeVariables': {
-  'primaryColor': '#eaf1fb',
-  'primaryTextColor': '#132d50',
-  'primaryBorderColor': '#43658f',
-  'lineColor': '#43658f',
-  'secondaryColor': '#f6f8fc',
-  'tertiaryColor': '#ffffff',
-  'fontFamily': 'ui-sans-serif, system-ui, sans-serif'
-}}}%%
-flowchart TB
+flowchart LR
   subgraph cli["cmd/agentshield switch os.Args[1]"]
-    cli_version["version"]
-    cli_rulepack["rulepack"]
-    cli_scan["scan"]
-    cli_admit["admit"]
-    cli_pubkey["pubkey"]
-    cli_verify["verify"]
-    cli_serve["serve"]
-    cli_inventory["inventory"]
-    cli_export["export"]
-    cli_sync["sync"]
-    cli_policy_exec["policy-exec"]
-    cli_hook["hook"]
-    cli_adapter["adapter"]
-    cli_grant["grant"]
-    cli_openshell["openshell"]
-    cli_release_manifest["release-manifest"]
-    cli_manifest_verify["manifest-verify"]
-    cli_incomplete["incomplete"]
+    %% Invisible links below arrange inventory rows only; they are not code relationships.
+    subgraph cli_row_0[" "]
+      direction LR
+      cli_version["version"]
+      cli_rulepack["rulepack"]
+      cli_scan["scan"]
+      cli_admit["admit"]
+      cli_version ~~~ cli_rulepack ~~~ cli_scan ~~~ cli_admit
+    end
+    style cli_row_0 fill:transparent,stroke:transparent
+    subgraph cli_row_1[" "]
+      direction LR
+      cli_pubkey["pubkey"]
+      cli_verify["verify"]
+      cli_serve["serve"]
+      cli_inventory["inventory"]
+      cli_pubkey ~~~ cli_verify ~~~ cli_serve ~~~ cli_inventory
+    end
+    style cli_row_1 fill:transparent,stroke:transparent
+    subgraph cli_row_2[" "]
+      direction LR
+      cli_export["export"]
+      cli_sync["sync"]
+      cli_policy_exec["policy-exec"]
+      cli_hook["hook"]
+      cli_export ~~~ cli_sync ~~~ cli_policy_exec ~~~ cli_hook
+    end
+    style cli_row_2 fill:transparent,stroke:transparent
+    subgraph cli_row_3[" "]
+      direction LR
+      cli_adapter["adapter"]
+      cli_grant["grant"]
+      cli_openshell["openshell"]
+      cli_release_manifest["release-manifest"]
+      cli_adapter ~~~ cli_grant ~~~ cli_openshell ~~~ cli_release_manifest
+    end
+    style cli_row_3 fill:transparent,stroke:transparent
+    subgraph cli_row_4[" "]
+      direction LR
+      cli_manifest_verify["manifest-verify"]
+      cli_incomplete["incomplete"]
+      cli_manifest_verify ~~~ cli_incomplete
+    end
+    style cli_row_4 fill:transparent,stroke:transparent
   end
   subgraph http["internal/server New() ServeMux"]
-    rt__v1_tasks_["/v1/tasks/"]
-    rt__v1_network_observations["/v1/network-observations"]
-    rt__v1_file_observation_recoveries["/v1/file-observation-recoveries"]
-    rt__v1_file_observations["/v1/file-observations"]
-    rt__v1_file_observations_["/v1/file-observations/"]
-    rt__v1_effect_observers["/v1/effect-observers"]
-    rt__v1_effect_observers_["/v1/effect-observers/"]
-    rt__v1_effect_evidence["/v1/effect-evidence"]
-    rt__v1_tool_effect_reports["/v1/tool-effect-reports"]
-    rt__v1_effect_evidence_["/v1/effect-evidence/"]
-    rt__v1_actions_["/v1/actions/"]
-    rt__v1_provenance_issuers["/v1/provenance-issuers"]
-    rt__v1_provenance_issuers_["/v1/provenance-issuers/"]
-    rt__v1_provenance_assertions["/v1/provenance-assertions"]
-    rt__v1_provenance_assertions_import["/v1/provenance-assertions/import"]
-    rt__v1_provenance_resolve["/v1/provenance-resolve"]
-    rt__v1_provenance_reports["/v1/provenance-reports"]
-    rt__v1_provenance_select["/v1/provenance-select"]
-    rt__v1_intents["/v1/intents"]
-    rt__v1_context_assertions["/v1/context-assertions"]
-    rt__v1_context_assertions_["/v1/context-assertions/"]
-    rt__v1_intents_["/v1/intents/"]
-    rt__v1_intent_bindings["/v1/intent-bindings"]
-    rt__v1_intent_bindings_["/v1/intent-bindings/"]
-    rt__v1_status["/v1/status"]
-    rt__v1_decide["/v1/decide"]
-    rt__v1_observe["/v1/observe"]
-    rt__v1_hold_status["/v1/hold-status"]
-    rt__v1_hold_["/v1/hold/"]
-    rt__v1_receipts["/v1/receipts"]
-    rt__v1_admit["/v1/admit"]
-    rt__v1_admissions["/v1/admissions"]
-    rt__v1_admissions_["/v1/admissions/"]
-    rt__v1_inventory["/v1/inventory"]
-    rt__v1_grants["/v1/grants"]
-    rt__v1_grants_["/v1/grants/"]
-    rt__v1_config["/v1/config"]
-    rt__v1_adapter_status["/v1/adapter/status"]
-    rt__v1_adapter_install["/v1/adapter/install"]
-    rt__v1_adapter_uninstall["/v1/adapter/uninstall"]
-    rt__v1_openshell_probe["/v1/openshell/probe"]
-    rt__v1_openshell_doctor["/v1/openshell/doctor"]
-    rt__v1_openshell_apply["/v1/openshell/apply"]
-    rt__v1_openshell_drift_check["/v1/openshell/drift-check"]
-    rt__v1_assets["/v1/assets"]
-    rt__v1_assets_["/v1/assets/"]
-    rt__v1_permissions["/v1/permissions"]
-    rt__v1_findings["/v1/findings"]
-    rt__v1_findings_["/v1/findings/"]
-    rt__v1_audit["/v1/audit"]
-    rt__v1_export["/v1/export"]
-    rt__v1_pair["/v1/pair"]
-    rt__ui_config_json["/ui-config.json"]
-    rt__["/"]
-    rt__["/"]
+    %% Invisible links below arrange inventory rows only; they are not code relationships.
+    subgraph http_row_0[" "]
+      direction LR
+      rt__v1_tasks_["/v1/tasks/"]
+      rt__v1_network_observations["/v1/network-observations"]
+      rt__v1_file_observation_recoveries["/v1/file-observation-recoveries"]
+      rt__v1_file_observations["/v1/file-observations"]
+      rt__v1_tasks_ ~~~ rt__v1_network_observations ~~~ rt__v1_file_observation_recoveries ~~~ rt__v1_file_observations
+    end
+    style http_row_0 fill:transparent,stroke:transparent
+    subgraph http_row_1[" "]
+      direction LR
+      rt__v1_file_observations_["/v1/file-observations/"]
+      rt__v1_effect_observers["/v1/effect-observers"]
+      rt__v1_effect_observers_["/v1/effect-observers/"]
+      rt__v1_effect_evidence["/v1/effect-evidence"]
+      rt__v1_file_observations_ ~~~ rt__v1_effect_observers ~~~ rt__v1_effect_observers_ ~~~ rt__v1_effect_evidence
+    end
+    style http_row_1 fill:transparent,stroke:transparent
+    subgraph http_row_2[" "]
+      direction LR
+      rt__v1_tool_effect_reports["/v1/tool-effect-reports"]
+      rt__v1_effect_evidence_["/v1/effect-evidence/"]
+      rt__v1_actions_["/v1/actions/"]
+      rt__v1_provenance_issuers["/v1/provenance-issuers"]
+      rt__v1_tool_effect_reports ~~~ rt__v1_effect_evidence_ ~~~ rt__v1_actions_ ~~~ rt__v1_provenance_issuers
+    end
+    style http_row_2 fill:transparent,stroke:transparent
+    subgraph http_row_3[" "]
+      direction LR
+      rt__v1_provenance_issuers_["/v1/provenance-issuers/"]
+      rt__v1_provenance_assertions["/v1/provenance-assertions"]
+      rt__v1_provenance_assertions_import["/v1/provenance-assertions/import"]
+      rt__v1_provenance_resolve["/v1/provenance-resolve"]
+      rt__v1_provenance_issuers_ ~~~ rt__v1_provenance_assertions ~~~ rt__v1_provenance_assertions_import ~~~ rt__v1_provenance_resolve
+    end
+    style http_row_3 fill:transparent,stroke:transparent
+    subgraph http_row_4[" "]
+      direction LR
+      rt__v1_provenance_reports["/v1/provenance-reports"]
+      rt__v1_provenance_select["/v1/provenance-select"]
+      rt__v1_intents["/v1/intents"]
+      rt__v1_context_assertions["/v1/context-assertions"]
+      rt__v1_provenance_reports ~~~ rt__v1_provenance_select ~~~ rt__v1_intents ~~~ rt__v1_context_assertions
+    end
+    style http_row_4 fill:transparent,stroke:transparent
+    subgraph http_row_5[" "]
+      direction LR
+      rt__v1_context_assertions_["/v1/context-assertions/"]
+      rt__v1_intents_["/v1/intents/"]
+      rt__v1_intent_bindings["/v1/intent-bindings"]
+      rt__v1_intent_bindings_["/v1/intent-bindings/"]
+      rt__v1_context_assertions_ ~~~ rt__v1_intents_ ~~~ rt__v1_intent_bindings ~~~ rt__v1_intent_bindings_
+    end
+    style http_row_5 fill:transparent,stroke:transparent
+    subgraph http_row_6[" "]
+      direction LR
+      rt__v1_status["/v1/status"]
+      rt__v1_decide["/v1/decide"]
+      rt__v1_observe["/v1/observe"]
+      rt__v1_hold_status["/v1/hold-status"]
+      rt__v1_status ~~~ rt__v1_decide ~~~ rt__v1_observe ~~~ rt__v1_hold_status
+    end
+    style http_row_6 fill:transparent,stroke:transparent
+    subgraph http_row_7[" "]
+      direction LR
+      rt__v1_hold_["/v1/hold/"]
+      rt__v1_receipts["/v1/receipts"]
+      rt__v1_admit["/v1/admit"]
+      rt__v1_admissions["/v1/admissions"]
+      rt__v1_hold_ ~~~ rt__v1_receipts ~~~ rt__v1_admit ~~~ rt__v1_admissions
+    end
+    style http_row_7 fill:transparent,stroke:transparent
+    subgraph http_row_8[" "]
+      direction LR
+      rt__v1_admissions_["/v1/admissions/"]
+      rt__v1_inventory["/v1/inventory"]
+      rt__v1_grants["/v1/grants"]
+      rt__v1_grants_["/v1/grants/"]
+      rt__v1_admissions_ ~~~ rt__v1_inventory ~~~ rt__v1_grants ~~~ rt__v1_grants_
+    end
+    style http_row_8 fill:transparent,stroke:transparent
+    subgraph http_row_9[" "]
+      direction LR
+      rt__v1_config["/v1/config"]
+      rt__v1_adapter_status["/v1/adapter/status"]
+      rt__v1_adapter_install["/v1/adapter/install"]
+      rt__v1_adapter_uninstall["/v1/adapter/uninstall"]
+      rt__v1_config ~~~ rt__v1_adapter_status ~~~ rt__v1_adapter_install ~~~ rt__v1_adapter_uninstall
+    end
+    style http_row_9 fill:transparent,stroke:transparent
+    subgraph http_row_10[" "]
+      direction LR
+      rt__v1_openshell_probe["/v1/openshell/probe"]
+      rt__v1_openshell_doctor["/v1/openshell/doctor"]
+      rt__v1_openshell_apply["/v1/openshell/apply"]
+      rt__v1_openshell_drift_check["/v1/openshell/drift-check"]
+      rt__v1_openshell_probe ~~~ rt__v1_openshell_doctor ~~~ rt__v1_openshell_apply ~~~ rt__v1_openshell_drift_check
+    end
+    style http_row_10 fill:transparent,stroke:transparent
+    subgraph http_row_11[" "]
+      direction LR
+      rt__v1_assets["/v1/assets"]
+      rt__v1_assets_["/v1/assets/"]
+      rt__v1_permissions["/v1/permissions"]
+      rt__v1_findings["/v1/findings"]
+      rt__v1_assets ~~~ rt__v1_assets_ ~~~ rt__v1_permissions ~~~ rt__v1_findings
+    end
+    style http_row_11 fill:transparent,stroke:transparent
+    subgraph http_row_12[" "]
+      direction LR
+      rt__v1_findings_["/v1/findings/"]
+      rt__v1_audit["/v1/audit"]
+      rt__v1_export["/v1/export"]
+      rt__v1_pair["/v1/pair"]
+      rt__v1_findings_ ~~~ rt__v1_audit ~~~ rt__v1_export ~~~ rt__v1_pair
+    end
+    style http_row_12 fill:transparent,stroke:transparent
+    subgraph http_row_13[" "]
+      direction LR
+      rt__ui_config_json["/ui-config.json"]
+      rt__["/"]
+      rt__ui_config_json ~~~ rt__
+    end
+    style http_row_13 fill:transparent,stroke:transparent
   end
   subgraph adp["adapters/runtime"]
     ad_codebuddy_agentshield["codebuddy-agentshield"]

--- a/site/diagrams/decide.mmd
+++ b/site/diagrams/decide.mmd
@@ -1,12 +1,3 @@
-%%{init: {'theme': 'base', 'themeVariables': {
-  'primaryColor': '#eaf1fb',
-  'primaryTextColor': '#132d50',
-  'primaryBorderColor': '#43658f',
-  'lineColor': '#43658f',
-  'secondaryColor': '#f6f8fc',
-  'tertiaryColor': '#ffffff',
-  'fontFamily': 'ui-sans-serif, system-ui, sans-serif'
-}}}%%
 flowchart TD
   dec["Engine.Decide"] --> ev["Engine.evaluate"]
   ev --> r0["deny: 'no deployed grant for agent (default deny)'"]

--- a/site/diagrams/from_code.py
+++ b/site/diagrams/from_code.py
@@ -33,17 +33,6 @@ ENGINE = INTERNAL / "receipt" / "engine.go"
 ADAPTERS_GO = INTERNAL / "adapters" / "adapters.go"
 ADAPTERS_DIR = REPO / "adapters" / "runtime"
 
-THEME = """%%{init: {'theme': 'base', 'themeVariables': {
-  'primaryColor': '#eaf1fb',
-  'primaryTextColor': '#132d50',
-  'primaryBorderColor': '#43658f',
-  'lineColor': '#43658f',
-  'secondaryColor': '#f6f8fc',
-  'tertiaryColor': '#ffffff',
-  'fontFamily': 'ui-sans-serif, system-ui, sans-serif'
-}}}%%
-"""
-
 
 def read(path: Path) -> str:
     return path.read_text(encoding="utf-8")
@@ -182,7 +171,7 @@ def extract_adapters() -> list[str]:
 
 def write_mmd(name: str, body: str) -> Path:
     path = OUT / name
-    path.write_text(THEME + body.strip() + "\n", encoding="utf-8")
+    path.write_text(body.strip() + "\n", encoding="utf-8")
     return path
 
 
@@ -196,14 +185,30 @@ def diagram_packages(pkgs: list[str], edges: list[tuple[str, str]]) -> str:
 
 
 def diagram_cli_http(cmds: list[str], routes: list[tuple[str, str]], adapters: list[str]) -> str:
-    lines = ["flowchart TB"]
+    lines = ["flowchart LR"]
+
+    def inventory_rows(prefix: str, entries: list[tuple[str, str]]) -> None:
+        # Mermaid reuses a node ID for duplicate registrations. Deduplicate before
+        # assigning rows so the same node never belongs to multiple subgraphs.
+        nodes = list(dict(entries).items())
+        lines.append("    %% Invisible links below arrange inventory rows only; they are not code relationships.")
+        for offset in range(0, len(nodes), 4):
+            row = nodes[offset:offset + 4]
+            row_id = f"{prefix}_row_{offset // 4}"
+            lines.append(f'    subgraph {row_id}[" "]')
+            lines.append("      direction LR")
+            for node_id, label in row:
+                lines.append(f'      {node_id}["{label}"]')
+            if len(row) > 1:
+                lines.append("      " + " ~~~ ".join(node_id for node_id, _ in row))
+            lines.append("    end")
+            lines.append(f"    style {row_id} fill:transparent,stroke:transparent")
+
     lines.append('  subgraph cli["cmd/agentshield switch os.Args[1]"]')
-    for c in cmds:
-        lines.append(f'    cli_{mermaid_id(c)}["{c}"]')
+    inventory_rows("cli", [(f"cli_{mermaid_id(c)}", c) for c in cmds])
     lines.append("  end")
     lines.append('  subgraph http["internal/server New() ServeMux"]')
-    for path, _ in routes:
-        lines.append(f'    rt_{mermaid_id(path)}["{path}"]')
+    inventory_rows("http", [(f"rt_{mermaid_id(path)}", path) for path, _ in routes])
     lines.append("  end")
     if adapters:
         lines.append('  subgraph adp["adapters/runtime"]')

--- a/site/diagrams/grant.mmd
+++ b/site/diagrams/grant.mmd
@@ -1,12 +1,3 @@
-%%{init: {'theme': 'base', 'themeVariables': {
-  'primaryColor': '#eaf1fb',
-  'primaryTextColor': '#132d50',
-  'primaryBorderColor': '#43658f',
-  'lineColor': '#43658f',
-  'secondaryColor': '#f6f8fc',
-  'tertiaryColor': '#ffffff',
-  'fontFamily': 'ui-sans-serif, system-ui, sans-serif'
-}}}%%
 stateDiagram-v2
   draft --> pending_approval
   draft --> rejected

--- a/site/diagrams/index.json
+++ b/site/diagrams/index.json
@@ -1,7 +1,7 @@
 {
   "generated_from": "site/diagrams/from_code.py",
   "note": "Static source extraction with fixed wiring templates; not complete control-flow analysis.",
-  "source_sha": "537e38546ee41d47588e8f422e7554f7abbd6ed6",
+  "source_sha": "a2f95c6fad1a04c776d57c4d4b9fd89b85c69b33",
   "source_dirty": true,
   "cli": [
     "version",

--- a/site/diagrams/packages.mmd
+++ b/site/diagrams/packages.mmd
@@ -1,12 +1,3 @@
-%%{init: {'theme': 'base', 'themeVariables': {
-  'primaryColor': '#eaf1fb',
-  'primaryTextColor': '#132d50',
-  'primaryBorderColor': '#43658f',
-  'lineColor': '#43658f',
-  'secondaryColor': '#f6f8fc',
-  'tertiaryColor': '#ffffff',
-  'fontFamily': 'ui-sans-serif, system-ui, sans-serif'
-}}}%%
 flowchart LR
   adapterinstall["adapterinstall"]
   adapters["adapters"]

--- a/site/diagrams/runtime.mmd
+++ b/site/diagrams/runtime.mmd
@@ -1,12 +1,3 @@
-%%{init: {'theme': 'base', 'themeVariables': {
-  'primaryColor': '#eaf1fb',
-  'primaryTextColor': '#132d50',
-  'primaryBorderColor': '#43658f',
-  'lineColor': '#43658f',
-  'secondaryColor': '#f6f8fc',
-  'tertiaryColor': '#ffffff',
-  'fontFamily': 'ui-sans-serif, system-ui, sans-serif'
-}}}%%
 flowchart LR
   subgraph host["this checkout"]
     skill["skills/siq-agent-security"]

--- a/site/styles.css
+++ b/site/styles.css
@@ -258,14 +258,20 @@ pre code { font-size: inherit; overflow-wrap: normal; }
 .toc-links { display: flex; flex-wrap: wrap; gap: .5rem 1.25rem; margin-top: 1.5rem; }
 .toc-links a { display: inline-flex; align-items: center; min-height: 44px; }
 .sources { color: var(--muted); font-size: .8rem; overflow-wrap: anywhere; }
-.diagram-controls { display: flex; flex-wrap: wrap; justify-content: space-between; align-items: center; gap: .5rem 1rem; margin: 1rem 0 .65rem; }
-.diagram-presets, .diagram-zoom { display: inline-flex; align-items: center; gap: .5rem; }
-.diagram-controls button { min-height: 44px; padding: .45rem .85rem; border: 1px solid var(--border); border-radius: 6px; background: var(--card); color: var(--ink); font: inherit; font-size: .85rem; cursor: pointer; }
-.diagram-controls button:hover { border-color: var(--accent); }
+.diagram-viewer { position: relative; overflow: hidden; background: var(--card); border: 1px solid var(--border); border-radius: 12px; box-shadow: var(--shadow-card); }
+.diagram-controls { position: absolute; right: .75rem; bottom: .75rem; z-index: 1; display: flex; align-items: center; padding: .2rem; border: 1px solid var(--border); border-radius: 8px; background: var(--card); box-shadow: var(--shadow-card); }
+.diagram-presets, .diagram-zoom { display: inline-flex; align-items: center; }
+.diagram-presets { border-left: 1px solid var(--border); margin-left: .2rem; padding-left: .2rem; }
+.diagram-controls button { display: inline-grid; place-items: center; width: 44px; height: 44px; padding: .5rem; border: 0; border-radius: 4px; background: transparent; color: var(--ink); font: inherit; font-size: .8rem; cursor: pointer; }
+.diagram-controls button:hover { background: var(--surface); }
+.diagram-controls svg { width: 20px; height: 20px; fill: none; stroke: currentColor; stroke-width: 1.7; stroke-linecap: round; stroke-linejoin: round; }
 .diagram-controls button:disabled { opacity: .45; cursor: default; }
-.diagram-scale { min-width: 3.5rem; text-align: center; color: var(--muted); font-size: .85rem; font-variant-numeric: tabular-nums; }
-.diagram-frame { overflow: auto; max-height: min(70vh, 44rem); padding: 1rem; background: var(--card); border: 1px solid var(--border); border-radius: 12px; box-shadow: var(--shadow-card); }
-.diagram-canvas { width: max-content; min-width: 100%; overflow: visible; font-family: var(--font); line-height: 1.5; }
+.diagram-scale { min-width: 3rem; text-align: center; color: var(--muted); font-size: .8rem; font-variant-numeric: tabular-nums; }
+.diagram-frame { overflow: auto; height: var(--diagram-height, 24rem); min-height: 16rem; max-height: min(65vh, 38rem); padding: 1.25rem 1.25rem 4.75rem; }
+.diagram-frame:focus-visible { outline-offset: -3px; }
+.diagram-frame.is-pannable { cursor: grab; }
+.diagram-frame.is-dragging { cursor: grabbing; user-select: none; }
+.diagram-canvas { display: grid; place-items: center; width: max-content; min-width: 100%; min-height: 100%; overflow: visible; font-family: var(--font); line-height: 1.5; }
 .diagram-canvas svg { display: block; max-width: none; margin-inline: auto; font-family: var(--font); }
 .diagram-hint { margin: .6rem 0 0; color: var(--muted); font-size: .8rem; }
 #diagrams .section { padding: 0 0 3rem; }

--- a/site/styles.css
+++ b/site/styles.css
@@ -258,9 +258,16 @@ pre code { font-size: inherit; overflow-wrap: normal; }
 .toc-links { display: flex; flex-wrap: wrap; gap: .5rem 1.25rem; margin-top: 1.5rem; }
 .toc-links a { display: inline-flex; align-items: center; min-height: 44px; }
 .sources { color: var(--muted); font-size: .8rem; overflow-wrap: anywhere; }
-.diagram-frame { overflow: auto; max-height: 44rem; padding: 1.2rem; background: var(--card); border: 1px solid var(--border); border-radius: 12px; box-shadow: var(--shadow-card); }
-.diagram-frame pre { padding: 0; background: transparent; color: var(--text); border-radius: 0; }
-.diagram-frame svg { max-width: none; }
+.diagram-controls { display: flex; flex-wrap: wrap; justify-content: space-between; align-items: center; gap: .5rem 1rem; margin: 1rem 0 .65rem; }
+.diagram-presets, .diagram-zoom { display: inline-flex; align-items: center; gap: .5rem; }
+.diagram-controls button { min-height: 44px; padding: .45rem .85rem; border: 1px solid var(--border); border-radius: 6px; background: var(--card); color: var(--ink); font: inherit; font-size: .85rem; cursor: pointer; }
+.diagram-controls button:hover { border-color: var(--accent); }
+.diagram-controls button:disabled { opacity: .45; cursor: default; }
+.diagram-scale { min-width: 3.5rem; text-align: center; color: var(--muted); font-size: .85rem; font-variant-numeric: tabular-nums; }
+.diagram-frame { overflow: auto; max-height: min(70vh, 44rem); padding: 1rem; background: var(--card); border: 1px solid var(--border); border-radius: 12px; box-shadow: var(--shadow-card); }
+.diagram-canvas { width: max-content; min-width: 100%; overflow: visible; font-family: var(--font); line-height: 1.5; }
+.diagram-canvas svg { display: block; max-width: none; margin-inline: auto; font-family: var(--font); }
+.diagram-hint { margin: .6rem 0 0; color: var(--muted); font-size: .8rem; }
 #diagrams .section { padding: 0 0 3rem; }
 
 @media (max-width: 1050px) { .nav { flex-wrap: wrap; padding-block: .75rem; gap: .25rem; } .nav-links { gap: .2rem 1.2rem; } }


### PR DESCRIPTION
源码架构页默认完整展示每张 Mermaid 图，缩放工具放在图内右下角；读者先查看全局，再主动放大、拖动查看细节，并可一键恢复全图。同时修复节点文字截断、嵌套滚动和 CLI/HTTP 清单横向过宽的问题。

## 改动

- 初始视图同时按图框宽度和高度缩放，完整容纳所有节点；图框随图形比例调整，并限制最大高度。
- 图内工具提供放大、缩小、显示全图和原始尺寸，预留底部空间以免遮挡初始图形。按钮带可访问名称、提示与键盘支持。
- 放大后支持鼠标拖动、原生滚动和方向键查看；工具固定在图内，不随图形滚走。改变窗口宽高时自动适配全图，手动倍率则保持不变。
- 使用普通图形容器，统一 Mermaid 测量和显示字体，并等待字体就绪后渲染，避免 `<pre>` 的等宽字体导致截字。
- CLI/HTTP 清单按每行最多 4 个节点布局，收紧图形间距。该图自然宽度从约 13,744px 降至 3,028px。
- 移除生成文件中覆盖站点主题的旧配置，重新生成六张 Mermaid 图和源码索引。

源码提取结果保持一致：CLI/HTTP 的 75 个唯一节点及标签、5 条真实连线未变，布局使用的不可见连线已在生成文件中注明。其余五张图仅移除旧主题前缀，图正文不变。变更仅涉及 `site/`。

## 验证

- `node --check site/architecture.js`
- `python3 scripts/check_site.py`
- `python3 scripts/check_site_mermaid_vendor.py`
- `python3 scripts/check_pages_action_pins.py`
- `git diff --check`
- 对比基线索引与生成图，确认提取事实、节点标签及真实连线保持一致。
- Playwright 实际浏览器验收：1440×960、390×844、320×568 三种视口均成功渲染六张图，默认无需内部滚动即可显示完整 SVG。
- 每种视口以原始尺寸检查 377 处标签，均无文字宽度截断；图内工具没有溢出或遮挡初始图形。
- 验证键盘缩放、鼠标拖动、方向键滚动、工具固定位置及一键复位；页面无横向溢出，无脚本错误。
- 验证窗口宽度、高度变化后默认仍完整展示全图，以及手动 125% 倍率跨窗口尺寸保持不变。
- 独立代码复审与拖动取消状态检查通过。

查看方式参考 GitHub Viewscreen 的默认整体适配与图内右下角控件布局：[公开 Viewer 实现](https://viewscreen.githubusercontent.com/static/assets/mermaidMarkdown-7616bad5582574bb905a.js.map)、[公开 Viewer 样式](https://viewscreen.githubusercontent.com/static/assets/mermaid-7616bad5582574bb905a.css)。

可通过 `python3 -m http.server 48725 --directory site` 启动本地预览，在 `/architecture.html` 查看。合并后由现有 Pages workflow 更新线上站点。
