### PR TITLE
ci: 配置可选 SonarCloud 审查与 CodeFlow 接入指引

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1,0 +1,72 @@
+name: sonarcloud
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  notice:
+    name: SonarCloud setup status (not a quality gate)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Explain optional analysis
+        env:
+          SCAN_ENABLED: ${{ vars.SONAR_ENABLED }}
+        run: |
+          if [ "$SCAN_ENABLED" != "true" ]; then
+            echo 'SonarCloud is not enabled. No scan or quality-gate result is claimed.' >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo 'SonarCloud is configured as optional. The analysis job checks event eligibility and project settings; this notice is not a successful quality gate.' >> "$GITHUB_STEP_SUMMARY"
+          fi
+          echo 'Fork PRs, Dependabot and non-main manual runs do not receive the Sonar token. Same-repository PR analysis requires its own enable flag.' >> "$GITHUB_STEP_SUMMARY"
+          echo 'Maintainer setup: docs/research/code-review-services.md' >> "$GITHUB_STEP_SUMMARY"
+
+  sonarcloud:
+    name: SonarCloud Code Analysis
+    if: >-
+      github.repository == 'maoyadongsh/siq-agent-security' &&
+      vars.SONAR_ENABLED == 'true' &&
+      github.actor != 'dependabot[bot]' &&
+      (
+        ((github.event_name == 'push' || github.event_name == 'workflow_dispatch') &&
+         github.ref == 'refs/heads/main') ||
+        (github.event_name == 'pull_request' &&
+         vars.SONAR_PR_ANALYSIS_ENABLED == 'true' &&
+         github.event.pull_request.user.login != 'dependabot[bot]' &&
+         github.event.pull_request.head.repo.full_name == github.repository &&
+         github.event.pull_request.base.ref == 'main')
+      )
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Validate non-secret Cloud settings
+        id: config
+        env:
+          SONAR_ORGANIZATION: ${{ vars.SONAR_ORGANIZATION }}
+          SONAR_PROJECT_KEY: ${{ vars.SONAR_PROJECT_KEY }}
+          SONAR_REGION: ${{ vars.SONAR_REGION }}
+          SONAR_HOST_URL: ${{ vars.SONAR_HOST_URL }}
+        run: python3 scripts/research/sonarcloud_config.py
+      - name: Analyze and wait for the actual quality gate
+        uses: SonarSource/sonarqube-scan-action@22918119ff8e1ca75a623e15c8296b6ea4fbe28f # v8.2.1
+        with:
+          skipSignatureVerification: 'false'
+          args: >-
+            -Dsonar.organization=${{ steps.config.outputs.organization }}
+            -Dsonar.projectKey=${{ steps.config.outputs.project_key }}
+            -Dsonar.qualitygate.wait=true
+            -Dsonar.qualitygate.timeout=300
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_REGION: ${{ steps.config.outputs.region }}

--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ secrets/
 
 # Isolated competition runtime, fixtures, model output and credentials
 .tmp/
+
+# Local SonarScanner output (not source or review evidence).
+.scannerwork/

--- a/docs/research/README.md
+++ b/docs/research/README.md
@@ -29,3 +29,5 @@ There is no published paper, DOI, independent reproduction badge or statisticall
 ## Progress and release operations
 
 The [execution ledger](../open-source-research-tasks-20260908.md) distinguishes completed repository engineering from pending experimental, external reproduction, archival and publication work. The [operations report](operations-20260908.md) records actual remote changes and release blockers.
+
+Optional repository review services: [CodeFlow and SonarCloud setup](code-review-services.md). Configuration tests do not establish that external services are authorized or scanning.

--- a/docs/research/code-review-services.md
+++ b/docs/research/code-review-services.md
@@ -1,0 +1,69 @@
+# CodeFlow 与 SonarCloud 代码审查
+
+本轮接入的服务是 [CodeFlow](https://app.getcodeflow.com/) 和 SonarCloud Code Analysis，不是 GitHub CodeQL。仓库端已提供可选 SonarCloud CI 配置；实际账号授权、项目绑定及首次扫描尚未完成。CodeFlow 需仓库管理员从服务界面连接，当前没有本仓库的真实分析结果。
+
+现有 gitleaks、Ruff、Go vet/test、依赖审计和安全回归继续运行。静态分析结果用于审阅，不能产生产品的 effective 权限，也不能替代安全不变量测试或人工审核。
+
+## SonarCloud 的维护者启用步骤
+
+1. 在 SonarCloud 中导入或选择本仓库，记录界面给出的 organization key、project key 与区域。绑定正确的 GitHub 仓库和 PR 反馈权限；不要把 GitHub 用户名自动当作 organization key。
+2. 使用本 PR 的 CI 分析前，在 Project → Administration → Analysis Method 关闭 Automatic Analysis。两种分析同时启用会使 CI 分析失败；删除配置文件不会代替服务端切换。
+3. 在原仓库 Settings → Secrets and variables → Actions 配置下表。当前操作账号 `sunbos` 对 `maoyadongsh/siq-agent-security` 仅有 READ 权限，不能替维护者配置这些设置。
+4. 合并配置后先开启 main 分析，通过主分支 push 或在 main 手动运行 `sonarcloud` 工作流建立基线。确认结果确实包含预期源码和测试分类。
+5. 核验组织计划的 PR 分析能力，再开启同仓 PR 分析并实际验证一个 PR。fork 与 Dependabot 仍不上传；当前 PR #29 就属于 fork PR，不能声称这套凭据方案已为它提供 Sonar 分析。
+6. 取得真实扫描结果、核对现有告警和质量门配置后，再决定合并门禁。不要把 setup notice 或跳过的扫描 job 设为 required check；当前方案也不适合作为要求所有 fork PR 必须通过的统一门禁。
+
+| 配置 | 类型 | 内容 |
+| --- | --- | --- |
+| `SONAR_ORGANIZATION` | Actions variable | SonarCloud 实际组织 key |
+| `SONAR_PROJECT_KEY` | Actions variable | SonarCloud 实际项目 key |
+| `SONAR_REGION` | Actions variable，可省略 | EU 留空或 `eu`；US 为 `us` |
+| `SONAR_TOKEN` | Actions secret | 有权分析该项目的 token，不能写入配置文件、日志或 PR |
+| `SONAR_ENABLED` | Actions variable | 首次启用 main 分析时设为 `true`，默认未启用 |
+| `SONAR_PR_ANALYSIS_ENABLED` | Actions variable | 完成基线和计划核验后设为 `true`，默认不分析同仓 PR |
+
+这份配置专用于 Cloud：`SONAR_HOST_URL` 应留空。参数脚本拒绝非空 Server URL、空项目标识、控制字符和注入额外参数的值。Cloud US 使用 `SONAR_REGION=us`，不通过覆盖 host URL 模拟区域。
+
+工作流限制为原仓库 main，以及明确启用后的同仓 main 目标 PR。Action 固定为 [v8.2.1 的 commit](https://github.com/SonarSource/sonarqube-scan-action/tree/22918119ff8e1ca75a623e15c8296b6ea4fbe28f)，保留 Scanner 签名校验；checkout 不保存 Git 凭据。只有扫描步骤获取 `SONAR_TOKEN`，该 job 不运行 npm lifecycle、测试或被扫描 Skill 脚本。没有 `pull_request_target`、特权 `workflow_run` 或自动合并路径。
+
+扫描设置 `sonar.qualitygate.wait=true`，最多等待质量门 300 秒。扫描失败、服务处理超时或质量门失败都会使分析任务失败，不使用 `continue-on-error` 将其伪装成成功。未启用时的 setup status 明确说明没有扫描，不代表质量门通过。
+
+## 分析范围与覆盖率
+
+[sonar-project.properties](../../sonar-project.properties) 把 `apps`、`edge`、`connectors`、`adapters`、`scripts`、`packages` 作为一个多语言项目；正常 Go/Python/JS/TS 测试归入 tests。嵌入的 UI 构建产物、适配器复制件、依赖缓存和指定测试语料单独排除。`skills`、`benchmarks` 和文档证据不在本轮源码范围内，恶意语料继续由原有安全回归负责。
+
+本轮**没有接入覆盖率报告**。当前文件也没有虚构报告路径或通过排除所有测试美化指标。SonarCloud 不自行产生覆盖率：后续需测试 job 实际生成 Go coverprofile、Python Cobertura XML、JS/TS LCOV，再分别配置 `sonar.go.coverage.reportPaths`、`sonar.python.coverage.reportPaths`、`sonar.javascript.lcov.reportPaths`。生成报告的测试阶段不持有 Sonar token。
+
+若项目质量门要求新代码覆盖率，维护者应先补齐真实报告再采用该要求；首次质量门失败不能解释为 CI 配置已经证明代码不安全，也不能删掉检查来伪称通过。
+
+## CodeFlow 的维护者接入步骤
+
+1. 从 [CodeFlow 应用](https://app.getcodeflow.com/) 选择 GitHub 登录，核对实际授权页面显示的发布者和权限。
+2. 由原仓库 admin/owner 选择 `maoyadongsh/siq-agent-security`。官方 [Getting Started](https://www.getcodeflow.com/getting-started.html) 说明首次注册 webhook 需要 admin；如果当前界面要求安装 GitHub App，以界面中的真实 App 和仓库授权为准，不猜测 App slug 或安装 URL。
+3. 注册仓库并执行第一次 main 分析。之后用一个 PR 核验新增/解决问题对比、实际分析文件、耗时和反馈位置，参照官方 [PR 分析说明](https://www.getcodeflow.com/pull-requests.html)。
+4. 首次实际运行后记录检查名称和覆盖范围，再决定是否启用 required check；本轮不能把用户提供的 `CodeFlow analyze results` 当作已验证的 GitHub check context。
+
+2026-09-12 只读检查中，应用 HTML 和公开 JS 可获取；这仅证明公开入口可达，不证明登录或分析后端已完成验证。公开文档仍包含旧版工具示例。官方[语言列表](https://www.getcodeflow.com/supported-languages.html)列出 Python、JavaScript/TypeScript 等，但未列出 Go；现代 Python/TS 和 monorepo 配置发现必须通过首次扫描验证。
+
+官方仅查到 linter 原生配置，例如 [Pylint](https://www.getcodeflow.com/pylint-configuration.html) 和 [ESLint](https://www.getcodeflow.com/eslint-configuration.html)；没有查到可采用的官方 `.codeflow.yml` 或 GitHub Action。为此本轮不创建同名占位文件，不将旧 TSLint/Pylint 示例强行替换现有工具。CodeFlow 的[安全说明](https://www.getcodeflow.com/security.html)说明服务会克隆仓库并保存展示报告需要的代码片段，授权应由负责人完成。
+
+## 验证与实际状态
+
+离线验证命令：
+
+```bash
+python3 -m unittest discover -s scripts/research -p 'test_*.py'
+ruff check scripts/research
+python3 scripts/research/check_metadata.py
+python3 scripts/check_research_task_ledger.py
+python3 scripts/check_ci_action_pins.py
+git diff --check
+```
+
+参数测试覆盖 EU/US、缺失配置、控制字符与参数注入、空/非空 host、token 不被读取和输出失败。workflow 契约测试拒绝移除 fork/main/Dependabot 条件、扩散 token、浮动 Action、跳过签名校验和放宽质量门。
+
+2026-09-12 本地验证：30 项 research 单测通过（20 项本轮参数/工作流测试、10 项既有测试），ruff、元数据、任务台账与既有 Actions pin 检查通过；使用模拟的非秘密组织/项目标识验证了 GitHub 输出文件格式，没有上传分析数据。
+
+服务端状态仍为 `external_manual`：尚无 SonarCloud organization/project key 或可用 token；未授权 CodeFlow，未修改原仓库 settings/secrets/保护规则；未执行任何真实 SonarCloud/CodeFlow 扫描。不能将离线配置测试算作线上 Code Analysis 通过。
+
+官方依据：[Sonar Scan Action](https://github.com/SonarSource/sonarqube-scan-action)、[Cloud 分析参数](https://docs.sonarsource.com/sonarqube-cloud/advanced-setup/analysis-parameters/parameters-not-settable-in-ui)、[Automatic Analysis](https://docs.sonarsource.com/sonarqube-cloud/advanced-setup/automatic-analysis)、[覆盖率参数](https://docs.sonarsource.com/sonarqube-cloud/enriching/test-coverage/test-coverage-parameters)。

--- a/docs/superpowers/plans/2026-09-12-code-review-services.md
+++ b/docs/superpowers/plans/2026-09-12-code-review-services.md
@@ -1,0 +1,28 @@
+# Code Review Services Implementation Plan
+
+**Goal:** 为已确认的 CodeFlow 与 SonarCloud 准备可审阅、可验证的仓库接入，准确列出维护者侧启用条件。
+
+**Architecture:** SonarCloud scope properties + 固定 Action workflow + stdlib 参数校验；离线结构测试保护凭据与事件边界。CodeFlow 使用已核实的官方服务能力，不臆造配置。
+
+**Tech Stack:** GitHub Actions、Python stdlib、仓库已有 PyYAML、官方 SonarSource Action。
+
+## 1. 参数与安全边界
+
+- [x] `scripts/research/test_sonarcloud_config.py` 先验证缺失、控制字符、参数注入及 region/host 混用被拒绝；`scripts/research/sonarcloud_config.py` 仅输出经校验的非秘密连接参数。
+- [x] 新增 workflow 契约检查与负向修改测试，拒绝 `pull_request_target`、fork token 路径、浮动 Action、跳过签名验证或假质量门成功。
+
+## 2. 仓库配置
+
+- [x] `sonar-project.properties` 使用真实源码目录；正常测试分离，构建产物与指定语料排除；不写 organization、token 或不存在的覆盖率路径。
+- [x] `.github/workflows/sonarcloud.yml` 先由 `SONAR_ENABLED` 开启 main 扫描，再由 `SONAR_PR_ANALYSIS_ENABLED` 开启同仓 PR；fork/Dependabot 不上传。扫描前运行参数校验，Action 等待质量门。
+- [x] `.gitignore` 排除本地 `.scannerwork/`；在既有 research CI 中运行新的离线测试。
+
+## 3. 维护者交接
+
+- [x] `docs/research/code-review-services.md` 记录连接变量、secret 名称、GitHub App 权限、Automatic Analysis 切换、覆盖率真实状态和 required check 启用条件。
+- [x] 核实 CodeFlow 端点与官方接入说明；记录无法验证的服务状态，不冒充完成授权。
+- [x] 复跑 `python3 -m unittest discover -s scripts/research -p 'test_*.py'`、`ruff check scripts/research`、研究元数据/台账及 `git diff --check`，独立审阅后交付。
+
+## 交付状态
+
+仓库配置与维护者指引完成；30项research单测（20项本轮、10项既有）通过，独立审阅发现的准入语料范围遗漏已修复并以真实路径做回归测试。实际服务启用仍为external_manual：未登录/授权CodeFlow，未取得SonarCloud组织、项目和token，也未执行线上扫描或修改原仓库治理设置。采用此前确认的fork PR审核方式，交给原仓库负责人审阅与配置。

--- a/docs/superpowers/specs/2026-09-12-code-review-services-design.md
+++ b/docs/superpowers/specs/2026-09-12-code-review-services-design.md
@@ -1,0 +1,21 @@
+# CodeFlow 与 SonarCloud 审查接入
+
+用户已明确服务为 `https://app.getcodeflow.com/` 和 SonarCloud Code Analysis。本轮准备仓库端静态审查配置，不改产品 runtime、合同或冻结证据；独立于 Skills 分发 PR #29，基线为 `1e20635843c0966e24d73d149e3d7bcd080f89c4`。
+
+## 方案
+
+SonarCloud 使用官方固定版本的 GitHub Action，以一个多语言项目分析 Go、Python、JS/TS 源码。选择 CI 分析而非 Automatic Analysis，以便明确排除生成产物和研究语料、将来接收真实覆盖率。服务端启用需维护者关闭 Automatic Analysis 并绑定项目。
+
+默认不开启上传。维护者填写 organization/project key、可选区域及 `SONAR_TOKEN` 后开启主分支基线分析；同仓 PR 另有开关，在完成主分支基线及计划能力核验后启用。fork PR、Dependabot、非 main 手动触发不读取 Sonar token，不使用 `pull_request_target` 或特权 `workflow_run` 执行 PR 内容。
+
+所有 Action 固定完整 commit，checkout 不持久化凭据。参数校验拒绝空字段、控制字符和额外参数；Cloud 区域与 Server URL 分开。只有扫描 Action 获取 token，保留 Scanner 签名验证，等待真实质量门；失败与超时不能显示为扫描通过。
+
+正常测试文件单独归 tests。排除构建输出、vendor、复制的嵌入适配器以及明确的恶意语料；不以排除全部测试或伪造覆盖率改善指标。未生成覆盖率报告时不配置虚假报告路径。
+
+CodeFlow 通过其官方服务接入。先核验可达性、GitHub 授权方式和语言覆盖；没有已验证的官方配置格式时不创建猜测性的 YAML，也不替换成 CodeQL。账号登录、组织授权和保护规则由原仓库维护者执行；当前 GitHub 账号对原仓库仅有 READ 权限。
+
+## 验收
+
+- 离线参数测试和 workflow 安全契约测试覆盖配置缺失、参数注入、fork 凭据边界、Action pin、真实质量门和禁用状态。
+- 既有 research 单测、元数据、台账及 Actions 检查通过；无产品代码改动。
+- 文档区分“仓库配置完成”和“线上服务启用”。首次真实 main/PR 分析及 CodeFlow 服务确认前，不声明审查生效，不设置 required check。

--- a/scripts/research/sonarcloud_config.py
+++ b/scripts/research/sonarcloud_config.py
@@ -1,0 +1,54 @@
+"""Validate nonsecret SonarCloud parameters before a CI scan."""
+
+from collections.abc import Mapping
+import json
+import os
+import re
+import sys
+
+
+IDENTIFIER = re.compile(r"[A-Za-z0-9_.:-]{1,255}")
+
+
+def cloud_parameters(env: Mapping[str, str]) -> dict[str, str]:
+    """Return validated public identifiers; never inspect authentication tokens."""
+    if env.get("SONAR_HOST_URL", "") != "":
+        raise ValueError("SONAR_HOST_URL")
+    result = {}
+    for field, output in (
+        ("SONAR_ORGANIZATION", "organization"),
+        ("SONAR_PROJECT_KEY", "project_key"),
+    ):
+        value = env.get(field, "")
+        if not isinstance(value, str) or IDENTIFIER.fullmatch(value) is None:
+            raise ValueError(field)
+        result[output] = value
+    region = env.get("SONAR_REGION", "")
+    if region not in ("", "eu", "us"):
+        raise ValueError("SONAR_REGION")
+    result["region"] = "us" if region == "us" else ""
+    return result
+
+
+def main() -> int:
+    try:
+        parameters = cloud_parameters(os.environ)
+    except ValueError as error:
+        print(f"invalid configuration: {error}", file=sys.stderr)
+        return 1
+    output = os.environ.get("GITHUB_OUTPUT", "")
+    if not output:
+        print(json.dumps(parameters, sort_keys=True))
+        return 0
+    try:
+        with open(output, "a", encoding="utf-8") as stream:
+            stream.write("".join(f"{key}={value}\n" for key, value in parameters.items()))
+    except (OSError, ValueError):
+        print("invalid configuration: GITHUB_OUTPUT", file=sys.stderr)
+        return 1
+    print("configuration validated")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/research/test_sonarcloud_config.py
+++ b/scripts/research/test_sonarcloud_config.py
@@ -1,0 +1,129 @@
+"""Offline validation of the SonarCloud CI configuration boundary."""
+
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+
+from sonarcloud_config import cloud_parameters
+
+
+SCRIPT = Path(__file__).with_name("sonarcloud_config.py")
+VALID = {"SONAR_ORGANIZATION": "example-org", "SONAR_PROJECT_KEY": "example:project.v1"}
+
+
+class CloudParametersTests(unittest.TestCase):
+    def test_missing_configuration_fails_with_only_field_name(self):
+        for field in VALID:
+            for value in (None, ""):
+                env = VALID.copy()
+                if value is None:
+                    del env[field]
+                else:
+                    env[field] = value
+                with self.subTest(field=field, value=value):
+                    with self.assertRaisesRegex(ValueError, f"^{field}$"):
+                        cloud_parameters(env)
+
+    def test_rejects_whitespace_control_unicode_and_parameter_injection(self):
+        for field in VALID:
+            for value in (
+                " a", "a ", "a b", "a\t", "a\n", "a\r", "a\x00", "a\x1b",
+                "a\u200b", "项目", "a/../b", "a\\b", "a=token", 'a"', "a'",
+                "$(id)", "`id`", "a;-Dsonar.host.url=https://evil.invalid", "a" * 256,
+            ):
+                with self.subTest(field=field, value=repr(value)):
+                    with self.assertRaisesRegex(ValueError, f"^{field}$"):
+                        cloud_parameters({**VALID, field: value})
+
+    def test_rejects_invalid_region(self):
+        for region in ("EU", "US", "asia", "eu\n", " us", "us -X", "us\x00"):
+            with self.subTest(region=repr(region)):
+                with self.assertRaisesRegex(ValueError, "^SONAR_REGION$"):
+                    cloud_parameters({**VALID, "SONAR_REGION": region})
+
+    def test_rejects_nonempty_host_override(self):
+        for host in ("https://sonarcloud.io", "https://evil.invalid", "\n"):
+            with self.subTest(host=repr(host)):
+                with self.assertRaisesRegex(ValueError, "^SONAR_HOST_URL$"):
+                    cloud_parameters({**VALID, "SONAR_HOST_URL": host})
+
+    def test_empty_host_matches_unset_github_variable(self):
+        self.assertEqual(cloud_parameters({**VALID, "SONAR_HOST_URL": ""}), cloud_parameters(VALID))
+
+    def test_eu_default_and_explicit_eu(self):
+        expected = {"organization": "example-org", "project_key": "example:project.v1", "region": ""}
+        for extra in ({}, {"SONAR_REGION": ""}, {"SONAR_REGION": "eu"}):
+            self.assertEqual(cloud_parameters({**VALID, **extra}), expected)
+
+    def test_us_and_full_supported_identifier_range(self):
+        self.assertEqual(
+            cloud_parameters({"SONAR_ORGANIZATION": "AZaz09_.:-", "SONAR_PROJECT_KEY": "a" * 255, "SONAR_REGION": "us"}),
+            {"organization": "AZaz09_.:-", "project_key": "a" * 255, "region": "us"},
+        )
+
+    def test_does_not_read_token(self):
+        class GuardedEnvironment(dict):
+            def get(self, key, default=None):
+                if key == "SONAR_TOKEN":
+                    raise AssertionError("Token must not be read")
+                return super().get(key, default)
+
+            def __getitem__(self, key):
+                if key == "SONAR_TOKEN":
+                    raise AssertionError("Token must not be read")
+                return super().__getitem__(key)
+
+        env = GuardedEnvironment({**VALID, "SONAR_TOKEN": "never-read-this"})
+        self.assertNotIn("never-read-this", json.dumps(cloud_parameters(env)))
+
+
+class CloudConfigCLITests(unittest.TestCase):
+    def run_cli(self, configuration):
+        env = {"PATH": os.defpath, **configuration, "SONAR_TOKEN": "token-sentinel-do-not-print"}
+        return subprocess.run([sys.executable, str(SCRIPT)], env=env, text=True, capture_output=True, check=False)
+
+    def test_cli_append_output_without_token(self):
+        with tempfile.TemporaryDirectory() as directory:
+            output = Path(directory) / "output"
+            output.write_text("existing=value\n", encoding="utf-8")
+            result = self.run_cli({**VALID, "SONAR_REGION": "us", "GITHUB_OUTPUT": str(output)})
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual(result.stdout, "configuration validated\n")
+            self.assertEqual(result.stderr, "")
+            self.assertEqual(output.read_text(encoding="utf-8"), "existing=value\norganization=example-org\nproject_key=example:project.v1\nregion=us\n")
+            self.assertNotIn("token-sentinel", result.stdout + result.stderr)
+
+    def test_cli_invalid_configuration_preserves_output_and_redacts_value(self):
+        with tempfile.TemporaryDirectory() as directory:
+            output = Path(directory) / "output"
+            output.write_text("existing=value\n", encoding="utf-8")
+            result = self.run_cli({**VALID, "SONAR_PROJECT_KEY": "secret-invalid-value\ninjected=yes", "GITHUB_OUTPUT": str(output)})
+            self.assertNotEqual(result.returncode, 0)
+            self.assertEqual(result.stdout, "")
+            self.assertEqual(result.stderr, "invalid configuration: SONAR_PROJECT_KEY\n")
+            self.assertEqual(output.read_text(encoding="utf-8"), "existing=value\n")
+            self.assertNotIn("secret-invalid-value", result.stderr)
+            self.assertNotIn("token-sentinel", result.stderr)
+
+    def test_cli_output_write_failure_has_no_success_and_no_path(self):
+        with tempfile.TemporaryDirectory() as directory:
+            result = self.run_cli({**VALID, "GITHUB_OUTPUT": str(Path(directory) / "missing" / "output")})
+            self.assertNotEqual(result.returncode, 0)
+            self.assertEqual(result.stdout, "")
+            self.assertEqual(result.stderr, "invalid configuration: GITHUB_OUTPUT\n")
+            self.assertNotIn(directory, result.stderr)
+
+    def test_cli_without_github_output_returns_only_nonsecret_parameters(self):
+        result = self.run_cli(VALID)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(json.loads(result.stdout), {"organization": "example-org", "project_key": "example:project.v1", "region": ""})
+        self.assertEqual(result.stderr, "")
+        self.assertNotIn("token-sentinel", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/research/test_sonarcloud_workflow.py
+++ b/scripts/research/test_sonarcloud_workflow.py
@@ -1,0 +1,161 @@
+"""Security contracts for optional SonarCloud CI; no service access required."""
+
+from copy import deepcopy
+from fnmatch import fnmatchcase
+import json
+from pathlib import Path
+import re
+import unittest
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[2]
+SCAN_ACTION = "SonarSource/sonarqube-scan-action@22918119ff8e1ca75a623e15c8296b6ea4fbe28f"
+GUARD = """
+github.repository == 'maoyadongsh/siq-agent-security' &&
+vars.SONAR_ENABLED == 'true' &&
+github.actor != 'dependabot[bot]' &&
+(
+  ((github.event_name == 'push' || github.event_name == 'workflow_dispatch') &&
+   github.ref == 'refs/heads/main') ||
+  (github.event_name == 'pull_request' &&
+   vars.SONAR_PR_ANALYSIS_ENABLED == 'true' &&
+   github.event.pull_request.user.login != 'dependabot[bot]' &&
+   github.event.pull_request.head.repo.full_name == github.repository &&
+   github.event.pull_request.base.ref == 'main')
+)
+"""
+
+
+def validate_workflow(data):
+    """Reject changes that weaken the reviewed credential boundary."""
+    def require(condition):
+        if not condition:
+            raise ValueError("SonarCloud workflow contract violated")
+
+    require(set(data["on"]) == {"push", "pull_request", "workflow_dispatch"})
+    require(data["on"]["push"]["branches"] == ["main"])
+    require(data["on"]["pull_request"]["branches"] == ["main"])
+    require(data["permissions"] == {"contents": "read"})
+    require(set(data["jobs"]) == {"notice", "sonarcloud"})
+    job = data["jobs"]["sonarcloud"]
+    require("permissions" not in job)
+    require(" ".join(job["if"].split()) == " ".join(GUARD.split()))
+    require(int(job["timeout-minutes"]) <= 20)
+    steps = job["steps"]
+    checkout, config, scan = steps
+    require(checkout["with"] == {"fetch-depth": "0", "persist-credentials": "false"})
+    require(config["run"] == "python3 scripts/research/sonarcloud_config.py")
+    require(scan["uses"] == SCAN_ACTION)
+    require(scan["with"]["skipSignatureVerification"] == "false")
+    args = scan["with"]["args"].split()
+    require("-Dsonar.qualitygate.wait=true" in args)
+    require("-Dsonar.qualitygate.timeout=300" in args)
+    require(scan["env"]["SONAR_TOKEN"] == "${{ secrets.SONAR_TOKEN }}")
+    require(scan["env"]["SONAR_REGION"] == "${{ steps.config.outputs.region }}")
+    require("continue-on-error" not in job)
+    for item in data["jobs"].values():
+        require("permissions" not in item)
+        for step in item["steps"]:
+            require("continue-on-error" not in step)
+            if "uses" in step:
+                require(re.fullmatch(r"[\w-]+/[\w-]+@[0-9a-f]{40}", step["uses"]) is not None)
+    serialized = json.dumps(data)
+    require(serialized.count("secrets.") == 1)
+    require("pull_request_target" not in serialized and "workflow_run" not in serialized)
+
+
+class SonarWorkflowTests(unittest.TestCase):
+    def setUp(self):
+        self.workflow = yaml.load(
+            (ROOT / ".github/workflows/sonarcloud.yml").read_text(), Loader=yaml.BaseLoader
+        )
+
+    def test_workflow_credential_contract(self):
+        validate_workflow(self.workflow)
+
+    def test_privileged_events_are_rejected(self):
+        for event in ("pull_request_target", "workflow_run"):
+            changed = deepcopy(self.workflow)
+            changed["on"][event] = {}
+            with self.assertRaises(ValueError):
+                validate_workflow(changed)
+
+    def test_fork_and_main_guards_cannot_be_removed(self):
+        for guard in (
+            "github.event.pull_request.head.repo.full_name == github.repository",
+            "github.ref == 'refs/heads/main'",
+            "github.actor != 'dependabot[bot]'",
+            "github.event.pull_request.user.login != 'dependabot[bot]'",
+            "vars.SONAR_PR_ANALYSIS_ENABLED == 'true'",
+        ):
+            changed = deepcopy(self.workflow)
+            changed["jobs"]["sonarcloud"]["if"] = changed["jobs"]["sonarcloud"]["if"].replace(guard, "true")
+            with self.assertRaises(ValueError):
+                validate_workflow(changed)
+
+    def test_token_cannot_move_to_job_or_another_step(self):
+        changed = deepcopy(self.workflow)
+        changed["jobs"]["notice"]["env"] = {"SONAR_TOKEN": "${{ secrets.SONAR_TOKEN }}"}
+        with self.assertRaises(ValueError):
+            validate_workflow(changed)
+
+    def test_floating_actions_and_disabled_signature_check_are_rejected(self):
+        for field, value in (("uses", "SonarSource/sonarqube-scan-action@v8"), ("signature", "true")):
+            changed = deepcopy(self.workflow)
+            scan = changed["jobs"]["sonarcloud"]["steps"][-1]
+            if field == "uses":
+                scan["uses"] = value
+            else:
+                scan["with"]["skipSignatureVerification"] = value
+            with self.assertRaises(ValueError):
+                validate_workflow(changed)
+
+    def test_quality_gate_cannot_be_soft_passed(self):
+        changed = deepcopy(self.workflow)
+        changed["jobs"]["sonarcloud"]["continue-on-error"] = "true"
+        with self.assertRaises(ValueError):
+            validate_workflow(changed)
+        changed = deepcopy(self.workflow)
+        scan = changed["jobs"]["sonarcloud"]["steps"][-1]
+        scan["with"]["args"] = scan["with"]["args"].replace("-Dsonar.qualitygate.wait=true", "")
+        with self.assertRaises(ValueError):
+            validate_workflow(changed)
+
+    def test_scope_retains_normal_tests_without_fabricated_coverage(self):
+        properties = dict(
+            line.split("=", 1)
+            for line in (ROOT / "sonar-project.properties").read_text().splitlines()
+            if line and not line.startswith("#")
+        )
+        self.assertEqual(properties["sonar.sources"], properties["sonar.tests"])
+        for root in properties["sonar.sources"].split(","):
+            self.assertTrue((ROOT / root).is_dir())
+        for pattern in ("**/*_test.go", "**/test_*.py", "**/*.test.ts", "**/test-*.py", "**/test-*.cjs"):
+            self.assertIn(pattern, properties["sonar.test.inclusions"].split(","))
+        self.assertNotIn("**/tests/**", properties["sonar.test.exclusions"].split(","))
+        self.assertFalse(any("coverage" in key.lower() for key in properties))
+        self.assertNotIn("sonar.organization", properties)
+        self.assertNotIn("sonar.projectKey", properties)
+
+    def test_admission_corpus_is_excluded_but_implementation_and_tests_remain(self):
+        properties = dict(
+            line.split("=", 1)
+            for line in (ROOT / "sonar-project.properties").read_text().splitlines()
+            if line and not line.startswith("#")
+        )
+        fixture = "apps/agentshield/internal/admission/testdata/skills/malicious/py-env-exfil/scripts/exfil.py"
+        production = "apps/agentshield/internal/admission/admission.go"
+        test = "apps/agentshield/internal/admission/admission_test.go"
+        for name in (fixture, production, test):
+            self.assertTrue((ROOT / name).is_file())
+        for field in ("sonar.exclusions", "sonar.test.exclusions"):
+            patterns = properties[field].split(",")
+            self.assertTrue(any(fnmatchcase(fixture, p) for p in patterns))
+            self.assertFalse(any(fnmatchcase(production, p) for p in patterns))
+            self.assertFalse(any(fnmatchcase(test, p) for p in patterns))
+        self.assertTrue(any(fnmatchcase(test, p) for p in properties["sonar.test.inclusions"].split(",")))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,13 @@
+# A single multi-language project. Identity and credentials come from CI settings.
+sonar.projectName=SIQ Agent Security
+sonar.sourceEncoding=UTF-8
+sonar.sources=apps,edge,connectors,adapters,scripts,packages
+sonar.tests=apps,edge,connectors,adapters,scripts,packages
+sonar.test.inclusions=**/*_test.go,**/test_*.py,**/test-*.py,**/*_test.py,**/conftest.py,**/tests/**,**/*.test.ts,**/*.test.tsx,**/*.test.js,**/*.test.mjs,**/*.test.cjs,**/*.spec.ts,**/*.spec.tsx,**/*.spec.js,**/test-*.js,**/test-*.mjs,**/test-*.cjs
+
+# Generated/cached code, embedded copies, and deliberate attack fixtures.
+# Ordinary tests remain indexed as tests. V5/research evidence is outside sources.
+sonar.exclusions=**/node_modules/**,**/.venv/**,**/venv/**,**/__pycache__/**,**/vendor/**,**/dist/**,**/build/**,**/coverage/**,apps/agentshield/internal/ui/embedded/**,apps/agentshield/internal/adapterinstall/assets/**,apps/agentshield/testdata/**,apps/agentshield/internal/admission/testdata/skills/**,apps/control-api/app/tests/fixtures/**,packages/contracts/fixtures/**
+sonar.test.exclusions=**/node_modules/**,**/.venv/**,**/venv/**,**/__pycache__/**,**/vendor/**,**/dist/**,**/build/**,**/coverage/**,apps/agentshield/internal/ui/embedded/**,apps/agentshield/internal/adapterinstall/assets/**,apps/agentshield/testdata/**,apps/agentshield/internal/admission/testdata/skills/**,apps/control-api/app/tests/fixtures/**,packages/contracts/fixtures/**
+
+# No coverage report is claimed until the corresponding test job generates it.


### PR DESCRIPTION
当前仓库没有 SonarCloud 分析配置，也没有 CodeFlow 接入指引。本 PR 增加默认关闭的 SonarCloud 多语言审查工作流，并准备维护者连接 CodeFlow 的操作说明。配置合入后仍需维护者提供服务端身份、secret 与授权，才会产生真实分析结果。

## 变更与维护者操作

- SonarCloud 使用固定 SHA 的官方 scan-action v8.2.1，保留 Scanner 签名验证，按真实质量门结果成功/失败。
- main 分析通过 SONAR_ENABLED 启用；同仓 PR 另由 SONAR_PR_ANALYSIS_ENABLED 启用。fork、Dependabot 及非 main 手动运行不获取 Sonar token；没有 pull_request_target、特权 workflow_run 或自动合并。
- organization/project/region 在上传前严格校验；token 只注入扫描 Action。未配置时仅显示 setup notice，不声明扫描或质量门通过。
- 源码作为一个 Go/Python/JS/TS 多语言项目；正常测试保留为 tests，精确排除构建输出、复制件和准入恶意语料。没有虚构覆盖率报告。
- CodeFlow 已确认是 app.getcodeflow.com。官方首次接仓需要 admin 注册 webhook/按实际界面授权；没有查到可采用的官方 .codeflow.yml 或 Action，所以没有添加占位配置或换成 CodeQL。

维护者需在 SonarCloud 绑定本仓库、关闭 Automatic Analysis、配置组织/项目/区域及 SONAR_TOKEN，先验证 main 基线后再开启同仓 PR。CodeFlow 需管理员登录并选择仓库，再验证首个 main 和 PR 分析。公开 CodeFlow 语言列表没有声明 Go，不能推定完整工程覆盖；实际 check context 也需首扫确认。

## 来源、许可与 DCO

新增配置、Python 校验与测试、指引为本轮仓库工作编写，按仓库适用的现有许可提交；没有 vendoring SonarSource 或 CodeFlow 实现。Action 来源固定到官方 commit，文档保留官方依据。当前新提交没有 Signed-off-by，按 CONTRIBUTING.md 仍需贡献者完成适用 DCO 签署；不伪造作者认证。

## 已执行验证

```text
python3 -m unittest discover -s scripts/research -p 'test_*.py'  # 30 passed：20 新增 + 10 既有
ruff check scripts/research
python3 scripts/research/check_metadata.py
python3 scripts/check_research_task_ledger.py
python3 scripts/check_ci_action_pins.py
git diff --check
```

另用模拟的非秘密组织/项目验证了 GITHUB_OUTPUT 写入格式，无服务上传。独立审阅发现准入内部 Skill 语料漏排：新增真实恶意 Python 样本路径测试先失败，精确补充排除后通过；正常 admission.go 和 admission_test.go 仍被保留。参数/工作流负向测试覆盖注入、配置缺失、凭据扩散、fork/main/Dependabot 条件移除、浮动 Action、签名校验绕过和质量门软通过。

## 未完成的外部步骤与证据边界

尚无 SonarCloud organization/project key/token，未进行真实 Cloud 扫描；未登录或授权 CodeFlow，也未验证其当前分析后端与现代工具链兼容性。原仓库 settings、secrets、保护规则保持原样。首次 main/PR 实扫前不要设为 required check，当前跳过 fork 的 Sonar 方案不能作为所有贡献 PR 的统一强制门禁。

本 PR 独立于 Skills 分发 PR #29，基于 1e20635。没有修改 runtime、合同、Skill payload 或冻结 V5 材料，没有新攻击防护分母、发布签名或覆盖率声明。GitHub Actions 的实际执行状态以本 PR 页面为准。

[维护者完整启用指南](https://github.com/sunbos/siq-agent-security/blob/32027104325c71fbfac8c16417721b3614a67b71/docs/research/code-review-services.md) · [设计范围](https://github.com/sunbos/siq-agent-security/blob/32027104325c71fbfac8c16417721b3614a67b71/docs/superpowers/specs/2026-09-12-code-review-services-design.md)

请审核扫描范围、凭据边界和服务启用条件；合并及服务授权由原仓库维护者决定。
